### PR TITLE
Decouple riff version from invoker version

### DIFF
--- a/install_riff.sh
+++ b/install_riff.sh
@@ -6,7 +6,7 @@ go get github.com/projectriff/riff
 riff_home="`go env GOPATH`/src/github.com/projectriff/riff"
 riff_version=`cat ${riff_home}/VERSION`
 
-echo "riffVersion: $riff_version" > ~/.riff.yaml
+echo "riffVersion: latest" > ~/.riff.yaml
 
 kubectl create namespace riff-system
 


### PR DESCRIPTION
Use 'latest' tag by default for invokers. Individual functions can
specify an explicit vresion in the `create` file.