### PR TITLE
Shorten cluster name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 - '1.9'
 env:
   global:
-  - CLUSTER_NAME="ci-${TRAVIS_REPO_SLUG////-}-${TRAVIS_JOB_NUMBER//./-}"
+  - CLUSTER_NAME="fats-${TRAVIS_JOB_NUMBER//./-}"
 install: true
 before_script:
 - "./install_kubectl.sh"


### PR DESCRIPTION
Some resources in GKE truncate the cluster name as it is embedded into
their own name. The most useful part is the build number at the end of
the name, which is the first thing to be truncated.