### PR TITLE
Use --verbose while creating functions

### DIFF
--- a/functions/uppercase/run.sh
+++ b/functions/uppercase/run.sh
@@ -28,11 +28,8 @@ for invoker in command jar java java-local node; do
 
     # create function
     fats_echo "Creating $function_name as $invoker:"
-    riff function create $invoker $function_name $args --image $image
-
-    # wait for function to build and deploy
-    fats_echo "Waiting for $function_name to become ready:"
-    wait_kservice_ready "${function_name}" 'default'
+    riff function create $invoker $function_name $args --image $image --verbose
+    # TODO reduce/eliminate this sleep
     sleep 5
 
     # invoke function


### PR DESCRIPTION
Use function create `--verbose` to show build and function logs while waiting for the function to become ready. Not using a blind "Ready" poller should help errors be trapped quicker rather then the build timing out.