### PR TITLE
Allow namespace specific config per cluster

### DIFF
--- a/init_gke.sh
+++ b/init_gke.sh
@@ -2,6 +2,7 @@
 
 export USER_ACCOUNT="gcr.io/`gcloud config get-value project`"
 export SYSTEM_INSTALL_FLAGS=""
+export NAMESPACE_INIT_FLAGS="--secret push-credentials"
 
 wait_for_ingress_ready() {
   name=$1

--- a/init_minikube.sh
+++ b/init_minikube.sh
@@ -2,6 +2,7 @@
 
 export USER_ACCOUNT="${DOCKER_USERNAME}"
 export SYSTEM_INSTALL_FLAGS="--node-port"
+export NAMESPACE_INIT_FLAGS="--secret push-credentials"
 
 docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
 

--- a/init_pks.sh
+++ b/init_pks.sh
@@ -4,6 +4,7 @@
 
 export USER_ACCOUNT="gcr.io/`gcloud config get-value project`"
 export SYSTEM_INSTALL_FLAGS=""
+export NAMESPACE_INIT_FLAGS="--secret push-credentials"
 
 wait_for_ingress_ready() {
   name=$1

--- a/install_riff.sh
+++ b/install_riff.sh
@@ -23,4 +23,4 @@ wait_for_ingress_ready 'knative-ingressgateway' 'istio-system'
 # setup namespace
 kubectl create namespace $NAMESPACE
 fats_create_push_credentials $NAMESPACE
-riff namespace init $NAMESPACE --secret push-credentials
+riff namespace init $NAMESPACE $NAMESPACE_INIT_FLAGS


### PR DESCRIPTION
This will enable testing of `--dockerhub`, `--gcr`, `--manifest` flags for `riff namespace init`.