### PR TITLE
Take out the trash

### DIFF
--- a/cleanup_gke.sh
+++ b/cleanup_gke.sh
@@ -11,13 +11,8 @@ gcloud container clusters delete $CLUSTER_NAME
 set +o errexit
 set +o pipefail
 
-cluster_prefix=`$CLUSTER_NAME | cut -d '-' -f1`
+cluster_prefix=`echo $CLUSTER_NAME | cut -d '-' -f1`
 before=`date -d @$(( $(date +"%s") - 24*3600)) -u +%Y-%m-%dT%H:%M:%SZ` # yesterday
-
-echo "cluster: $CLUSTER_NAME"
-echo "cluster_prefix: $cluster_prefix"
-echo "before: $before"
-echo "gcloud container clusters list --filter=\"name ~ ^$cluster_prefix- AND createTime < $before\""
 
 fats_echo "Cleanup orphaned clusters"
 gcloud container clusters list --filter="name ~ ^$cluster_prefix- AND createTime < $before"

--- a/cleanup_pks.sh
+++ b/cleanup_pks.sh
@@ -18,7 +18,7 @@ pks delete-cluster ${TS_G_ENV}-${CLUSTER_NAME} --non-interactive --wait
 set +o errexit
 set +o pipefail
 
-cluster_prefix="${TS_G_ENV}-`$CLUSTER_NAME | cut -d '-' -f1`"
+cluster_prefix="${TS_G_ENV}-`echo $CLUSTER_NAME | cut -d '-' -f1`"
 before=`date -d @$(( $(date +"%s") - 24*3600)) -u +%Y-%m-%dT%H:%M:%SZ` # yesterday
 
 fats_echo "Cleanup orphaned clusters"


### PR DESCRIPTION
GKE and Bosh seem to orphan a number of resources. We should clean them
up periodically in order to avoid exceeding quota limits.

Fixes #67