### PR TITLE
Get zone from PKS master node

### DIFF
--- a/cleanup_pks.sh
+++ b/cleanup_pks.sh
@@ -5,11 +5,15 @@ source `dirname "${BASH_SOURCE[0]}"`/util.sh
 TS_G_ENV=$(echo $TOOLSMITH_ENV | base64 --decode | jq -r .name)
 
 gcp_region=`gcloud config get-value compute/region`
-gcp_zone=`gcloud config get-value compute/zone`
+lb_ip=`gcloud compute addresses list --filter="name=(${TS_G_ENV}-${CLUSTER_NAME}-ip)" --format=json | jq -r .[0].address`
 
-gcloud compute forwarding-rules delete ${TS_G_ENV}-${CLUSTER_NAME}-fw --region=${gcp_region}
-gcloud compute target-instances delete ${TS_G_ENV}-${CLUSTER_NAME}-ti --zone=${gcp_zone}
-gcloud compute addresses delete ${TS_G_ENV}-${CLUSTER_NAME}-ip --region=${gcp_region}
+gcloud dns record-sets transaction start --zone=${TS_G_ENV}-zone
+gcloud dns record-sets transaction remove ${lb_ip} --name=${pks_hostname}. --ttl=300 --type=A --zone=${TS_G_ENV}-zone
+gcloud dns record-sets transaction execute --zone=${TS_G_ENV}-zone
+
+gcloud compute forwarding-rules delete ${TS_G_ENV}-${CLUSTER_NAME}-fr --region ${gcp_region}
+gcloud compute target-pools delete ${TS_G_ENV}-${CLUSTER_NAME}-tp
+gcloud compute addresses delete ${TS_G_ENV}-${CLUSTER_NAME}-ip
 
 pks delete-cluster ${TS_G_ENV}-${CLUSTER_NAME} --non-interactive --wait
 

--- a/install_pks.sh
+++ b/install_pks.sh
@@ -22,22 +22,31 @@ UAA_ADMIN_PASSWORD=$(echo $TOOLSMITH_ENV | base64 --decode | jq -r .pks_api.uaa_
 pks login -a api.pks.${TS_G_ENV}.cf-app.com -u admin -p ${UAA_ADMIN_PASSWORD} -k
 
 gcp_region=`gcloud config get-value compute/region`
-gcp_zone=`gcloud config get-value compute/zone`
 
-gcloud compute addresses create ${TS_G_ENV}-${CLUSTER_NAME}-ip --region=${gcp_region}
+gcloud compute addresses create ${TS_G_ENV}-${CLUSTER_NAME}-ip --region ${gcp_region}
 lb_ip=`gcloud compute addresses list --filter="name=(${TS_G_ENV}-${CLUSTER_NAME}-ip)" --format=json | jq -r .[0].address`
 
-travis_wait 60 pks create-cluster ${TS_G_ENV}-${CLUSTER_NAME} --external-hostname ${lb_ip} --plan large --wait
+pks_hostname=${CLUSTER_NAME}.${TS_G_ENV}.cf-app.com
+
+gcloud dns record-sets transaction start --zone=${TS_G_ENV}-zone
+gcloud dns record-sets transaction add ${lb_ip} --name=${pks_hostname}. --ttl=300 --type=A --zone=${TS_G_ENV}-zone
+gcloud dns record-sets transaction execute --zone=${TS_G_ENV}-zone
+
+travis_wait 60 pks create-cluster ${TS_G_ENV}-${CLUSTER_NAME} --external-hostname ${pks_hostname} --plan large --wait
 
 master_ip=`pks cluster ${TS_G_ENV}-${CLUSTER_NAME} --json | jq -r .kubernetes_master_ips[0]`
-master_name=`gcloud compute instances list --filter="tags.items = pcf-${TS_G_ENV} AND tags.items = master AND and networkInterfaces.networkIP = ${master_ip}" --format="table[no-heading](name)"`
-gcloud compute target-instances create ${TS_G_ENV}-${CLUSTER_NAME}-ti \
-  --instance ${master_name} \
-  --zone=${gcp_zone}
-gcloud compute forwarding-rules create ${TS_G_ENV}-${CLUSTER_NAME}-fw \
-  --target-instance=${TS_G_ENV}-${CLUSTER_NAME}-ti \
-  --address=${lb_ip} \
-  --region=${gcp_region} \
-  --target-instance-zone=${gcp_zone}
+master_vm=`gcloud compute instances list --filter "tags.items = pcf-${TS_G_ENV} AND tags.items = master AND networkInterfaces.networkIP = ${master_ip}" --format "table[no-heading](name, zone)"`
+master_name=`echo $master_vm | cut -d " " -f 1`
+master_zone=`echo $master_vm | cut -d " " -f 2`
+
+gcloud compute target-pools create ${TS_G_ENV}-${CLUSTER_NAME}-tp
+gcloud compute target-pools add-instances ${TS_G_ENV}-${CLUSTER_NAME}-tp \
+  --instances ${master_name} \
+  --instances-zone ${master_zone}
+gcloud compute forwarding-rules create ${TS_G_ENV}-${CLUSTER_NAME}-fr \
+  --target-pool ${TS_G_ENV}-${CLUSTER_NAME}-tp \
+  --address ${lb_ip} \
+  --ports 8443 \
+  --region ${gcp_region}
 
 pks get-credentials ${TS_G_ENV}-${CLUSTER_NAME}


### PR DESCRIPTION
PKS vms are created by bosh in the zone bosh is configued to use. It may
not be the same zone that gcloud is defaulted to. In that case, when
configuring external access to the k8s api server, the zone of the
master node must be used.

Also configuring external DNS, for kicks