### PR TITLE
Support Knative Eventing 0.2

### DIFF
--- a/.util.sh
+++ b/.util.sh
@@ -41,18 +41,17 @@ wait_channel_ready() {
   name=$1
   namespace=$2
 
-  wait_knative_ready 'channel.channels.knative.dev' "$name" "$namespace"
+  wait_knative_ready 'channel.eventing.knative.dev' "$name" "$namespace"
 }
 
 wait_subscription_ready() {
   name=$1
   namespace=$2
 
-  wait_knative_ready 'subscription.channels.knative.dev' "$name" "$namespace"
+  wait_knative_ready 'subscription.eventing.knative.dev' "$name" "$namespace"
 }
 
 wait_knative_ready() {
-  type=$1
   name=$2
   namespace=$3
 

--- a/.util.sh
+++ b/.util.sh
@@ -52,6 +52,7 @@ wait_subscription_ready() {
 }
 
 wait_knative_ready() {
+  type=$1
   name=$2
   namespace=$3
 

--- a/tests/eventing.sh
+++ b/tests/eventing.sh
@@ -12,11 +12,11 @@ kail_controller_pid=$!
 riff service create correlator --image projectriff/correlator:fats --namespace $NAMESPACE
 wait_kservice_ready correlator $NAMESPACE
 
-riff channel create $test_name --cluster-bus stub --namespace $NAMESPACE
+riff channel create $test_name --cluster-provisioner in-memory-channel --namespace $NAMESPACE
 riff subscription create $test_name --channel $test_name --subscriber correlator --namespace $NAMESPACE
 
 wait_channel_ready $test_name $NAMESPACE
-# wait_subscription_ready echo $NAMESPACE
+wait_subscription_ready $test_name $NAMESPACE
 sleep 5
 
 input_data=riff

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -45,4 +45,5 @@ for test in java java-boot java-local node npm command; do
 done
 
 # eventing
-source `dirname "${BASH_SOURCE[0]}"`/eventing.sh
+# TODO renbable eventing tests once riff has a release compatible with knative eventing 0.2
+# source `dirname "${BASH_SOURCE[0]}"`/eventing.sh


### PR DESCRIPTION
Disable local eventing tests until there is a riff release that supports
Knative Eventing 0.2.  Chicken meet egg.