### PR TITLE
Install riff as a go module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 language: go
 go:
-- '1.11'
+- '1.11.4'
 dist: xenial
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ sudo: required
 language: go
 go:
 - '1.11.4'
+cache:
+  directories:
+  - $GOPATH/pkg/mod
 dist: xenial
 env:
   global:

--- a/tools/riff.sh
+++ b/tools/riff.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-go get github.com/projectriff/riff
+d=`mktemp -d riff.XXXX`
+
+pushd $d
+  echo 'module temp' > go.mod
+  GO111MODULE=on go get github.com/projectriff/riff@master
+popd
+
+rm -r "$d"


### PR DESCRIPTION
Adapt to changes now the riff uses go modules rather than dep. While this works. it's very slow as all dependencies to compile riff are fetched and downloaded. In the long run we should upload snapshot version of riff that can be consumed here.