### PR TITLE
Cleanup build output with folding

### DIFF
--- a/.configure.sh
+++ b/.configure.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 if [[ "${FATS_CONFIGURED:-x}" == "x" ]]; then
-  echo -e "Configuring FATS run:"
+  travis_fold start configure
+  echo -e "Configuring FATS"
   echo -e "    cluster ${ANSI_BLUE}${CLUSTER}${ANSI_RESET}"
   echo -e "    registry ${ANSI_BLUE}${REGISTRY}${ANSI_RESET}"
 
@@ -9,4 +10,5 @@ if [[ "${FATS_CONFIGURED:-x}" == "x" ]]; then
   source `dirname "${BASH_SOURCE[0]}"`/registries/${REGISTRY}/configure.sh
 
   FATS_CONFIGURED=true
+  travis_fold end configure
 fi

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -4,5 +4,12 @@ source `dirname "${BASH_SOURCE[0]}"`/.util.sh
 
 source `dirname "${BASH_SOURCE[0]}"`/.configure.sh
 
+travis_fold start cleanup-registry
+echo "Cleanup registry $REGISTRY"
 source `dirname "${BASH_SOURCE[0]}"`/registries/${REGISTRY}/cleanup.sh
+travis_fold end cleanup-registry
+
+travis_fold start cleanup-cluster
+echo "Cleanup cluster $CLUSTER"
 source `dirname "${BASH_SOURCE[0]}"`/clusters/${CLUSTER}/cleanup.sh
+travis_fold end cleanup-cluster

--- a/functions/helpers.sh
+++ b/functions/helpers.sh
@@ -83,15 +83,19 @@ run_function() {
 
   actual_data=`cat $function_name.out | tail -1`
   if [ "$actual_data" != "$expected_data" ]; then
-    fats_echo "Function Logs:"
+    travis_fold start function-$function_name-logs-function
+    echo -e "Function Logs:"
     cat $function_name.logs
-    echo ""
-    fats_echo "Controller Logs:"
+    travis_fold end function-$function_name-logs-function
+    echo -e ""
+    travis_fold start function-$function_name-logs-controller
+    echo -e "Controller Logs:"
     cat $function_name.controller.logs
-    echo ""
-    fats_echo "${ANSI_RED}Function did not produce expected result${ANSI_RESET}:";
-    echo "   expected: $expected_data"
-    echo "   actual: $actual_data"
+    travis_fold end function-$function_name-logs-controller
+    echo -e ""
+    echo -e "${ANSI_RED}Function did not produce expected result${ANSI_RESET}:";
+    echo -e "   expected: $expected_data"
+    echo -e "   actual: $actual_data"
     exit 1
   fi
 

--- a/functions/helpers.sh
+++ b/functions/helpers.sh
@@ -50,6 +50,8 @@ run_function() {
   input_data=$4
   expected_data=$5
 
+  travis_fold start function-$function_name
+
   kail --ns $NAMESPACE --label "function=$function_name" > $function_name.logs &
   kail_function_pid=$!
 
@@ -77,4 +79,6 @@ run_function() {
     echo "   actual: $actual_data"
     exit 1
   fi
+
+  travis_fold end function-$function_name
 }

--- a/functions/helpers.sh
+++ b/functions/helpers.sh
@@ -5,6 +5,9 @@ create_function() {
   function_name=$2
   image=$3
 
+  travis_fold start create-function-$function_name
+  echo "Create function $function_name"
+
   pushd $path
     args=""
     if [ -e '.fats/create' ]; then
@@ -18,6 +21,8 @@ create_function() {
     # TODO reduce/eliminate this sleep
     sleep 5
   popd
+
+  travis_fold end create-function-$function_name
 }
 
 invoke_function() {
@@ -25,7 +30,9 @@ invoke_function() {
   input_data=$2
   expected_data=$3
 
-  fats_echo "Invoking $function_name:"
+  travis_fold start invoke-function-$function_name
+  echo "Invoke function $function_name"
+
   riff service invoke $function_name --namespace $NAMESPACE -- \
     -H "Content-Type: text/plain" \
     -d $input_data \
@@ -33,14 +40,21 @@ invoke_function() {
 
   # add a new line after invoke, but without impacting the curl output
   echo ""
+
+  travis_fold end invoke-function-$function_name
 }
 
 destroy_function() {
   function_name=$1
   image=$2
 
+  travis_fold start destroy-function-$function_name
+  echo "Destroy function $function_name"
+
   riff service delete $function_name --namespace $NAMESPACE
   fats_delete_image $image
+
+  travis_fold end destroy-function-$function_name
 }
 
 run_function() {
@@ -51,6 +65,7 @@ run_function() {
   expected_data=$5
 
   travis_fold start function-$function_name
+  echo "Run function $function_name"
 
   kail --ns $NAMESPACE --label "function=$function_name" > $function_name.logs &
   kail_function_pid=$!

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if [ ! -f `dirname "${BASH_SOURCE[0]}"`/tools/$1.installed ]; then
-  travis_fold start $1
+  travis_fold start install-$1
   echo "Installing $1"
   `dirname "${BASH_SOURCE[0]}"`/tools/$1.sh
   touch `dirname "${BASH_SOURCE[0]}"`/tools/$1.installed
-  travis_fold end $1
+  travis_fold end install-$1
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 if [ ! -f `dirname "${BASH_SOURCE[0]}"`/tools/$1.installed ]; then
+  travis_fold start $1
   echo "Installing $1"
   `dirname "${BASH_SOURCE[0]}"`/tools/$1.sh
   touch `dirname "${BASH_SOURCE[0]}"`/tools/$1.installed
+  travis_fold end $1
 fi

--- a/registries/dockerhub/configure.sh
+++ b/registries/dockerhub/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Login for local pushes
-docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
+docker login --username $DOCKER_USERNAME --password-stdin <(echo "$DOCKER_PASSWORD")
 
 IMAGE_REPOSITORY_PREFIX="${DOCKER_USERNAME}"
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --secret push-credentials"

--- a/registries/dockerhub/configure.sh
+++ b/registries/dockerhub/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Login for local pushes
-docker login --username $DOCKER_USERNAME --password-stdin <(echo "$DOCKER_PASSWORD")
+echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
 
 IMAGE_REPOSITORY_PREFIX="${DOCKER_USERNAME}"
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --secret push-credentials"

--- a/start.sh
+++ b/start.sh
@@ -4,5 +4,12 @@ source `dirname "${BASH_SOURCE[0]}"`/.util.sh
 
 source `dirname "${BASH_SOURCE[0]}"`/.configure.sh
 
+travis_fold start start-cluster
+echo "Starting cluster $CLUSTER"
 source `dirname "${BASH_SOURCE[0]}"`/clusters/${CLUSTER}/start.sh
+travis_fold end start-cluster
+
+travis_fold start start-registry
+echo "Starting registry $REGISTRY"
 source `dirname "${BASH_SOURCE[0]}"`/registries/${REGISTRY}/start.sh
+travis_fold end start-registry

--- a/tests/cleanup.sh
+++ b/tests/cleanup.sh
@@ -4,12 +4,18 @@ set -o nounset
 
 # script failed, dump debug info
 if [ "$TRAVIS_TEST_RESULT" = "1" ]; then
+  travis_fold start debug
+  echo "Debug logs"
   sudo free -m -t
   sudo dmesg
+  travis_fold end debug
 fi
 
 # attempt to cleanup riff and the cluster
+travis_fold start system-uninstall
+echo "Uninstall riff system"
 riff system uninstall --istio --force || true
 kubectl delete namespace $NAMESPACE || true
+travis_fold end system-uninstall
 
 source `dirname "${BASH_SOURCE[0]}"`/../cleanup.sh

--- a/tests/cleanup.sh
+++ b/tests/cleanup.sh
@@ -2,6 +2,8 @@
 
 set -o nounset
 
+source `dirname "${BASH_SOURCE[0]}"`/../.util.sh
+
 # script failed, dump debug info
 if [ "$TRAVIS_TEST_RESULT" = "1" ]; then
   travis_fold start debug

--- a/tests/eventing.sh
+++ b/tests/eventing.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 # TODO make FATS channel tests modular enough to use here
+
+travis_fold start eventing
+echo "Eventing"
+
 test_name=echo
 
 kail --ns $NAMESPACE > $test_name.logs &
@@ -44,3 +48,5 @@ if [[ "$actual_data" != "$expected_data" ]]; then
   echo "   actual data: $actual_data"
   exit 1
 fi
+
+travis_fold end eventing

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -10,7 +10,7 @@ source `dirname "${BASH_SOURCE[0]}"`/../start.sh
 source `dirname "${BASH_SOURCE[0]}"`/../install.sh riff
 
 travis_fold start system-install
-echo "Install riff system"
+echo "Installing riff system"
 
 riff system install $SYSTEM_INSTALL_FLAGS
 
@@ -36,7 +36,6 @@ riff namespace init $NAMESPACE $NAMESPACE_INIT_FLAGS
 travis_fold end system-install
 
 # run test functions
-echo "Run functions"
 source `dirname "${BASH_SOURCE[0]}"`/../functions/helpers.sh
 
 # uppercase

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,6 +9,9 @@ source `dirname "${BASH_SOURCE[0]}"`/../start.sh
 # install riff
 source `dirname "${BASH_SOURCE[0]}"`/../install.sh riff
 
+travis_fold start system-install
+echo "Install riff system"
+
 riff system install $SYSTEM_INSTALL_FLAGS
 
 # health checks
@@ -29,6 +32,8 @@ wait_for_ingress_ready 'knative-ingressgateway' 'istio-system'
 kubectl create namespace $NAMESPACE
 fats_create_push_credentials $NAMESPACE
 riff namespace init $NAMESPACE $NAMESPACE_INIT_FLAGS
+
+travis_fold end system-install
 
 # run test functions
 echo "Run functions"


### PR DESCRIPTION
Using travis' folding support to collapse and organize the build output. Sections of the build that pass will have their output collapsed automatically as the build progresses, leaving a high level summary of what happened at the top level with details available be expanding the fold.