### PR TITLE
EKS cluster (and almost ECR registry) support

### DIFF
--- a/.configure.sh
+++ b/.configure.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 
-if [[ "${FATS_CONFIGURED:-x}" == "x" ]]; then
-  travis_fold start configure
-  echo -e "Configuring FATS"
-  echo -e "    cluster ${ANSI_BLUE}${CLUSTER}${ANSI_RESET}"
-  echo -e "    registry ${ANSI_BLUE}${REGISTRY}${ANSI_RESET}"
-
-  source `dirname "${BASH_SOURCE[0]}"`/clusters/${CLUSTER}/configure.sh
-  source `dirname "${BASH_SOURCE[0]}"`/registries/${REGISTRY}/configure.sh
-
-  FATS_CONFIGURED=true
-  travis_fold end configure
+if [[ "${FATS_CONFIGURED:-x}" == "true" ]]; then
+  return
 fi
+FATS_CONFIGURED=true
+
+source `dirname "${BASH_SOURCE[0]}"`/.util.sh
+
+travis_fold start configure
+echo -e "Configuring FATS"
+echo -e "    cluster ${ANSI_BLUE}${CLUSTER}${ANSI_RESET}"
+echo -e "    registry ${ANSI_BLUE}${REGISTRY}${ANSI_RESET}"
+
+source `dirname "${BASH_SOURCE[0]}"`/clusters/${CLUSTER}/configure.sh
+source `dirname "${BASH_SOURCE[0]}"`/registries/${REGISTRY}/configure.sh
+
+travis_fold end configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - REGISTRY=gcr
   - env:
     - CLUSTER=eks
-    - REGISTRY=ecr
+    - REGISTRY=dockerhub
   # disable pks-gcp because creating the cluster take as long as travis job time limit
   # - env:
   #   - CLUSTER=pks-gcp

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
   - env:
     - CLUSTER=gke
     - REGISTRY=gcr
+  - env:
+    - CLUSTER=eks
+    - REGISTRY=dockerhub
   # disable pks-gcp because creating the cluster take as long as travis job time limit
   # - env:
   #   - CLUSTER=pks-gcp

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
     - REGISTRY=gcr
   - env:
     - CLUSTER=eks
-    - REGISTRY=dockerhub
+    - REGISTRY=ecr
   # disable pks-gcp because creating the cluster take as long as travis job time limit
   # - env:
   #   - CLUSTER=pks-gcp

--- a/.util.sh
+++ b/.util.sh
@@ -32,7 +32,7 @@ wait_for_service_hostname() {
     'service' \
     "$namespace" \
     "$name" \
-    '{$.status.loadBalancer.ingress[].hostname:}' \
+    '{$.status.loadBalancer.ingress[].hostname}' \
     "$pattern"
 }
 

--- a/.util.sh
+++ b/.util.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ "${FATS_LOADED:-x}" == "x" ]]; then
+  return
+fi
+FATS_LOADED=true
+
 source `dirname "${BASH_SOURCE[0]}"`/.travis.sh
 source `dirname "${BASH_SOURCE[0]}"`/install.sh kubectl
 source `dirname "${BASH_SOURCE[0]}"`/install.sh kail

--- a/.util.sh
+++ b/.util.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [[ "${FATS_LOADED:-x}" == "x" ]]; then
+if [[ "${FATS_LOADED:-x}" == "true" ]]; then
   return
 fi
 FATS_LOADED=true

--- a/.util.sh
+++ b/.util.sh
@@ -18,6 +18,19 @@ wait_for_service_ip() {
     '[0-9]'
 }
 
+wait_for_service_hostname() {
+  local name=$1
+  local namespace=$2
+  local pattern=$3
+
+  wait_kube_ready \
+    'service' \
+    "$namespace" \
+    "$name" \
+    '{$.status.loadBalancer.ingress[].hostname:}' \
+    "$pattern"
+}
+
 wait_pod_selector_ready() {
   local label=$1
   local namespace=$2

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Support is provided for:
 To add a new registry, create a directory under `./registries/` and add three files:
 
 - `configure.sh` - configuration for the registry
-  - set `IMAGE_REPOSITORY_PREFIX` env var that includes repository host and user information that can be pushed to
   - set `NAMESPACE_INIT_FLAGS` env var that is passed to `riff namespace init`
+  - define function `fats_image_repo` that echos the Docker repository to push the image to
   - define function `fats_delete_image` that deletes a published image
   - define function `fats_create_push_credentials` that creates a secret to be used to push in cluster builds to the registry
   - do any other one time configuration for the registry (run before the cluster is started)

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source `dirname "${BASH_SOURCE[0]}"`/.util.sh
-
 source `dirname "${BASH_SOURCE[0]}"`/.configure.sh
 
 travis_fold start cleanup-registry

--- a/clusters/eks/cleanup.sh
+++ b/clusters/eks/cleanup.sh
@@ -2,4 +2,4 @@
 
 # delete job resources
 
-eksctl delete cluster --name $CLUSTER_NAME
+eksctl delete cluster --name $CLUSTER_NAME --verbose 4

--- a/clusters/eks/cleanup.sh
+++ b/clusters/eks/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# delete job resources
+
+eksctl delete cluster --name $CLUSTER_NAME

--- a/clusters/eks/configure.sh
+++ b/clusters/eks/configure.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Install eksctl cli
+source `dirname "${BASH_SOURCE[0]}"`/../../install.sh eksctl
+
+SYSTEM_INSTALL_FLAGS="${SYSTEM_INSTALL_FLAGS:-}"
+
+wait_for_ingress_ready() {
+  local name=$1
+  local namespace=$2
+
+  wait_for_service_ip $name $namespace
+}

--- a/clusters/eks/configure.sh
+++ b/clusters/eks/configure.sh
@@ -9,5 +9,5 @@ wait_for_ingress_ready() {
   local name=$1
   local namespace=$2
 
-  wait_for_service_ip $name $namespace
+  wait_for_service_hostname $name $namespace .elb.amazonaws.com
 }

--- a/clusters/eks/start.sh
+++ b/clusters/eks/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-travis_wait 40 eksctl create cluster --name $CLUSTER_NAME --version 1.11
+eksctl create cluster --name $CLUSTER_NAME --version 1.11

--- a/clusters/eks/start.sh
+++ b/clusters/eks/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-travis_wait eksctl create cluster --name $CLUSTER_NAME
+travis_wait 40 eksctl create cluster --name $CLUSTER_NAME

--- a/clusters/eks/start.sh
+++ b/clusters/eks/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-eksctl get cluster --name $CLUSTER_NAME
+eksctl create cluster --name $CLUSTER_NAME

--- a/clusters/eks/start.sh
+++ b/clusters/eks/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-eksctl create cluster --name $CLUSTER_NAME --version 1.11
+eksctl create cluster --name $CLUSTER_NAME --version 1.11 --verbose 4

--- a/clusters/eks/start.sh
+++ b/clusters/eks/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+eksctl get cluster --name $CLUSTER_NAME

--- a/clusters/eks/start.sh
+++ b/clusters/eks/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-travis_wait 40 eksctl create cluster --name $CLUSTER_NAME
+travis_wait 40 eksctl create cluster --name $CLUSTER_NAME --version 1.11

--- a/clusters/eks/start.sh
+++ b/clusters/eks/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-eksctl create cluster --name $CLUSTER_NAME --version 1.11 --verbose 4
+eksctl create cluster --name $CLUSTER_NAME --version 1.10 --verbose 4

--- a/clusters/eks/start.sh
+++ b/clusters/eks/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-eksctl create cluster --name $CLUSTER_NAME
+travis_wait eksctl create cluster --name $CLUSTER_NAME

--- a/functions/helpers.sh
+++ b/functions/helpers.sh
@@ -67,9 +67,9 @@ run_function() {
   travis_fold start function-$function_name
   echo "Run function $function_name"
 
-  echo -e "${ANSI_BLUE}> path:${ANSI_CLEAR} ${path}"
-  echo -e "${ANSI_BLUE}> name:${ANSI_CLEAR} ${function_name}"
-  echo -e "${ANSI_BLUE}> image:${ANSI_CLEAR} ${image}"
+  echo -e "${ANSI_BLUE}> path:${ANSI_RESET} ${path}"
+  echo -e "${ANSI_BLUE}> name:${ANSI_RESET} ${function_name}"
+  echo -e "${ANSI_BLUE}> image:${ANSI_RESET} ${image}"
 
   kail --ns $NAMESPACE --label "function=$function_name" > $function_name.logs &
   local kail_function_pid=$!

--- a/functions/helpers.sh
+++ b/functions/helpers.sh
@@ -67,6 +67,10 @@ run_function() {
   travis_fold start function-$function_name
   echo "Run function $function_name"
 
+  echo -e "${ANSI_BLUE}> path:${ANSI_CLEAR} ${path}"
+  echo -e "${ANSI_BLUE}> name:${ANSI_CLEAR} ${function_name}"
+  echo -e "${ANSI_BLUE}> image:${ANSI_CLEAR} ${image}"
+
   kail --ns $NAMESPACE --label "function=$function_name" > $function_name.logs &
   local kail_function_pid=$!
 

--- a/functions/helpers.sh
+++ b/functions/helpers.sh
@@ -78,7 +78,7 @@ run_function() {
   invoke_function $function_name $input_data $expected_data
 
   # cleanup resources
-  kill $kail_function_pid $kail_controller_pid || true
+  kill $kail_function_pid $kail_controller_pid
   destroy_function $function_name $image
 
   local actual_data=`cat $function_name.out | tail -1`

--- a/functions/helpers.sh
+++ b/functions/helpers.sh
@@ -78,7 +78,7 @@ run_function() {
   invoke_function $function_name $input_data $expected_data
 
   # cleanup resources
-  kill $kail_function_pid $kail_controller_pid
+  kill $kail_function_pid $kail_controller_pid || true
   destroy_function $function_name $image
 
   local actual_data=`cat $function_name.out | tail -1`

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+`dirname "${BASH_SOURCE[0]}"`/.util.sh
+
 if [ ! -f `dirname "${BASH_SOURCE[0]}"`/tools/$1.installed ]; then
   travis_fold start install-$1
   echo "Installing $1"

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-`dirname "${BASH_SOURCE[0]}"`/.util.sh
+source `dirname "${BASH_SOURCE[0]}"`/.util.sh
 
 if [ ! -f `dirname "${BASH_SOURCE[0]}"`/tools/$1.installed ]; then
   travis_fold start install-$1

--- a/registries/dockerhub/configure.sh
+++ b/registries/dockerhub/configure.sh
@@ -6,6 +6,13 @@ echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-st
 IMAGE_REPOSITORY_PREFIX="${DOCKER_USERNAME}"
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --secret push-credentials"
 
+fats_image_repo() {
+  local func=$1
+  local test=$2
+
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${func}-${test}:${CLUSTER}"
+}
+
 fats_delete_image() {
   local image
   IFS=':' read -r -a image <<< "$1"

--- a/registries/dockerhub/configure.sh
+++ b/registries/dockerhub/configure.sh
@@ -7,10 +7,9 @@ IMAGE_REPOSITORY_PREFIX="${DOCKER_USERNAME}"
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --secret push-credentials"
 
 fats_image_repo() {
-  local func=$1
-  local test=$2
+  local function_name=$1
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${func}-${test}:${CLUSTER}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}:${CLUSTER_NAME}"
 }
 
 fats_delete_image() {

--- a/registries/ecr/cleanup.sh
+++ b/registries/ecr/cleanup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# nothing to do

--- a/registries/ecr/configure.sh
+++ b/registries/ecr/configure.sh
@@ -9,6 +9,20 @@ $(aws ecr get-login --no-include-email --region us-west-2)
 IMAGE_REPOSITORY_PREFIX="$(aws sts get-caller-identity --output text --query 'Account').dkr.ecr.us-west-2.amazonaws.com"
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --secret push-credentials"
 
+fats_image_repo() {
+  local func=$1
+  local test=$2
+
+  local repo="fats-${func}-${test}"
+  local tag="${CLUSTER}"
+
+  # ECR requires the repo be created before pushing an image.
+  # allow to fail since the repository may already exist
+  aws ecr create-repository --repository-name $repo --region us-west-2 || true
+
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${repo}:${tag}"
+}
+
 fats_delete_image() {
   local image=$1
   IFS=':' read -r -a image <<< "$1"

--- a/registries/ecr/configure.sh
+++ b/registries/ecr/configure.sh
@@ -17,11 +17,8 @@ fats_image_repo() {
   local tag="${CLUSTER}"
 
   # ECR requires the repo be created before pushing an image.
-  travis_fold start create-repo-${repo}
-  echo "Create repo for ${repo}"
   # allow to fail since the repository may already exist
-  aws ecr create-repository --repository-name $repo --region us-west-2 || true
-  travis_fold end create-repo-${repo}
+  aws ecr create-repository --repository-name $repo --region us-west-2 1>&2 || true
 
   echo -n "${IMAGE_REPOSITORY_PREFIX}/${repo}:${tag}"
 }

--- a/registries/ecr/configure.sh
+++ b/registries/ecr/configure.sh
@@ -34,7 +34,7 @@ fats_create_push_credentials() {
   local token=`aws ecr get-authorization-token --region us-west-2 --output text --query 'authorizationData[].authorizationToken' | base64 --decode`
   local username=`echo $token | cut -d':' -f1`
   local password=`echo $token | cut -d':' -f2`
-  local endpoint="https://$(aws sts get-caller-identity --output text --query 'Account').dkr.ecr.us-west-2.amazonaws.com/"
+  local endpoint="https://$(aws sts get-caller-identity --output text --query 'Account').dkr.ecr.us-west-2.amazonaws.com/v2/"
 
   echo "Create auth secret"
   cat <<EOF | kubectl apply -f -

--- a/registries/ecr/configure.sh
+++ b/registries/ecr/configure.sh
@@ -10,17 +10,13 @@ IMAGE_REPOSITORY_PREFIX="$(aws sts get-caller-identity --output text --query 'Ac
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --secret push-credentials"
 
 fats_image_repo() {
-  local func=$1
-  local test=$2
-
-  local repo="fats-${func}-${test}"
-  local tag="${CLUSTER}"
+  local function_name=$1
 
   # ECR requires the repo be created before pushing an image.
   # allow to fail since the repository may already exist
-  aws ecr create-repository --repository-name $repo --region us-west-2 1>&2 || true
+  aws ecr create-repository --repository-name $function_name --region us-west-2 1>&2 || true
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${repo}:${tag}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}:${CLUSTER_NAME}"
 }
 
 fats_delete_image() {

--- a/registries/ecr/configure.sh
+++ b/registries/ecr/configure.sh
@@ -17,8 +17,11 @@ fats_image_repo() {
   local tag="${CLUSTER}"
 
   # ECR requires the repo be created before pushing an image.
+  travis_fold start create-repo-${repo}
+  echo "Create repo for ${repo}"
   # allow to fail since the repository may already exist
   aws ecr create-repository --repository-name $repo --region us-west-2 || true
+  travis_fold end create-repo-${repo}
 
   echo -n "${IMAGE_REPOSITORY_PREFIX}/${repo}:${tag}"
 }

--- a/registries/ecr/configure.sh
+++ b/registries/ecr/configure.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo -e "${ANSI_RED}NOTE: ECR will not fully work until https://github.com/knative/serving/issues/1996 is resolved${ANSI_RESET}"
+
 # Install aws for ECR access
 source `dirname "${BASH_SOURCE[0]}"`/../../install.sh aws
 

--- a/registries/ecr/configure.sh
+++ b/registries/ecr/configure.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Install aws for ECR access
+source `dirname "${BASH_SOURCE[0]}"`/../../install.sh aws
+
+# Login for local pushes
+$(aws ecr get-login --no-include-email --region us-west-2)
+
+aws sts get-caller-identity
+
+IMAGE_REPOSITORY_PREFIX="$(aws sts get-caller-identity | jq -r .Account).dkr.ecr.us-west-2.amazonaws.com"
+NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --secret push-credentials"
+
+fats_delete_image() {
+  local image=$1
+  IFS=':' read -r -a image <<< "$1"
+  local repo=${image[0]}
+  local tag=${image[1]}
+
+  aws ecr batch-delete-image --repository-name $repo --image-ids imageTag=$tag
+}
+
+fats_create_push_credentials() {
+  local namespace=$1
+
+  local login_cmd=`aws ecr get-login --no-include-email --region us-west-2`
+  if ! [[ "$login_cmd" =~ "^docker login -u (\S+) -p (\S+) (\S+)$" ]]; then
+    echo "Unexpected output from 'aws ecr get-login'"
+    exit 1
+  fi
+  local username="${BASH_REMATCH[1]}"
+  local password="${BASH_REMATCH[2]}"
+  local endpoint="${BASH_REMATCH[3]}"
+
+  echo "Create auth secret"
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: push-credentials
+  namespace: $(echo -n "$namespace")
+  annotations:
+    build.knative.dev/docker-0: $(echo -n "$endpoint")
+type: kubernetes.io/basic-auth
+data:
+  username: $(echo -n "$username")
+  password: $(echo -n "$password")
+EOF
+}

--- a/registries/ecr/start.sh
+++ b/registries/ecr/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# nothing to do

--- a/registries/gcr/configure.sh
+++ b/registries/gcr/configure.sh
@@ -7,10 +7,9 @@ IMAGE_REPOSITORY_PREFIX="gcr.io/`gcloud config get-value project`"
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --secret push-credentials"
 
 fats_image_repo() {
-  local func=$1
-  local test=$2
+  local function_name=$1
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${func}-${test}:${CLUSTER}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}:${CLUSTER_NAME}"
 }
 
 fats_delete_image() {

--- a/registries/gcr/configure.sh
+++ b/registries/gcr/configure.sh
@@ -6,6 +6,13 @@ source `dirname "${BASH_SOURCE[0]}"`/../../install.sh gcloud
 IMAGE_REPOSITORY_PREFIX="gcr.io/`gcloud config get-value project`"
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --secret push-credentials"
 
+fats_image_repo() {
+  local func=$1
+  local test=$2
+
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${func}-${test}:${CLUSTER}"
+}
+
 fats_delete_image() {
   local image=$1
 

--- a/registries/minikube/configure.sh
+++ b/registries/minikube/configure.sh
@@ -9,10 +9,9 @@ IMAGE_REPOSITORY_PREFIX="registry.kube-system.svc.cluster.local/u"
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --no-secret"
 
 fats_image_repo() {
-  local func=$1
-  local test=$2
+  local function_name=$1
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${func}-${test}:${CLUSTER}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}:${CLUSTER_NAME}"
 }
 
 fats_delete_image() {

--- a/registries/minikube/configure.sh
+++ b/registries/minikube/configure.sh
@@ -8,6 +8,13 @@ sudo systemctl restart docker
 IMAGE_REPOSITORY_PREFIX="registry.kube-system.svc.cluster.local/u"
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --no-secret"
 
+fats_image_repo() {
+  local func=$1
+  local test=$2
+
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${func}-${test}:${CLUSTER}"
+}
+
 fats_delete_image() {
   local image=$1
 

--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-source `dirname "${BASH_SOURCE[0]}"`/.util.sh
-
 source `dirname "${BASH_SOURCE[0]}"`/.configure.sh
 
 travis_fold start start-cluster

--- a/tests/eventing.sh
+++ b/tests/eventing.sh
@@ -31,7 +31,7 @@ riff service invoke correlator /$NAMESPACE/$test_name --namespace $NAMESPACE --t
 expected_data=riff
 actual_data=`cat $test_name.out | tail -1`
 
-kill $kail_test_pid $kail_controller_pid || true
+kill $kail_test_pid $kail_controller_pid
 riff subscription delete $test_name --namespace $NAMESPACE
 riff channel delete $test_name --namespace $NAMESPACE
 riff service delete correlator --namespace $NAMESPACE

--- a/tests/eventing.sh
+++ b/tests/eventing.sh
@@ -31,7 +31,7 @@ riff service invoke correlator /$NAMESPACE/$test_name --namespace $NAMESPACE --t
 expected_data=riff
 actual_data=`cat $test_name.out | tail -1`
 
-kill $kail_test_pid $kail_controller_pid
+kill $kail_test_pid $kail_controller_pid || true
 riff subscription delete $test_name --namespace $NAMESPACE
 riff channel delete $test_name --namespace $NAMESPACE
 riff service delete correlator --namespace $NAMESPACE

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -42,7 +42,7 @@ source `dirname "${BASH_SOURCE[0]}"`/../functions/helpers.sh
 for test in java java-boot java-local node npm command; do
   path=`dirname "${BASH_SOURCE[0]}"`/../functions/uppercase/${test}
   function_name=fats-uppercase-${test}
-  image=$(fats_image_repo uppercase ${test})
+  image=$(fats_image_repo ${function_name})
   input_data=riff
   expected_data=RIFF
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -42,7 +42,7 @@ source `dirname "${BASH_SOURCE[0]}"`/../functions/helpers.sh
 for test in java java-boot java-local node npm command; do
   path=`dirname "${BASH_SOURCE[0]}"`/../functions/uppercase/${test}
   function_name=fats-uppercase-${test}
-  image=${IMAGE_REPOSITORY_PREFIX}/fats-uppercase-${test}:${CLUSTER_NAME}
+  image=$(fats_image_repo uppercase ${test})
   input_data=riff
   expected_data=RIFF
 

--- a/tools/aws-iam-authenticator.sh
+++ b/tools/aws-iam-authenticator.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+version=0.4.0-alpha.1
+
+curl -s -L "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/${version}/aws-iam-authenticator_${version}_linux_amd64" -o aws-iam-authenticator
+chmod +x aws-iam-authenticator
+sudo mv aws-iam-authenticator /usr/local/bin

--- a/tools/eksctl.sh
+++ b/tools/eksctl.sh
@@ -2,6 +2,7 @@
 
 # Install aws cli
 source `dirname "${BASH_SOURCE[0]}"`/../install.sh aws
+source `dirname "${BASH_SOURCE[0]}"`/../install.sh aws-iam-authenticator
 
 eksctl_version="0.1.16"
 eksctl_dir=`mktemp -d eksctl.XXXX`

--- a/tools/eksctl.sh
+++ b/tools/eksctl.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Install aws cli
+source `dirname "${BASH_SOURCE[0]}"`/../install.sh aws
+
 eksctl_version="0.1.16"
 eksctl_dir=`mktemp -d eksctl.XXXX`
 

--- a/tools/eksctl.sh
+++ b/tools/eksctl.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+eksctl_version="0.1.15"
+eksctl_dir=`mktemp -d eksctl.XXXX`
+
+curl -s -L "https://github.com/weaveworks/eksctl/releases/download/${eksctl_version}/eksctl_Linux_amd64.tar.gz" \
+  | tar xz -C $eksctl_dir
+chmod +x $eksctl_dir/eksctl
+sudo mv $eksctl_dir/eksctl /usr/local/bin
+
+rm -rf $eksctl_dir

--- a/tools/eksctl.sh
+++ b/tools/eksctl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-eksctl_version="0.1.15"
+eksctl_version="0.1.16"
 eksctl_dir=`mktemp -d eksctl.XXXX`
 
 curl -s -L "https://github.com/weaveworks/eksctl/releases/download/${eksctl_version}/eksctl_Linux_amd64.tar.gz" \


### PR DESCRIPTION
Adds support for EKS clusters created via [eksctl](https://eksctl.io). The vast majority of support for ECR registries is also included, but fully support is blocked by [Knative Serving being unable to resolve an image digest](https://github.com/knative/serving/issues/1996).

A breaking change replaces the `IMAGE_REPOSITORY_PREFIX` var with an `fats_image_repo` function. The function echos the full image repository. This gives the registry provided the ability to perform imperative logic before a repository is used. For example, ECR requires the repository to be created before an image can be pushed, whereas other registries create repositories lazily.

Also includes minor refactoring and polish.

The AWS credentials saved in travis are for my personal sandbox. A request for a team account has been submitted to the powers that be.

Refs #15