### PR TITLE
Adapt eventing tests for Knative Eventing 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,10 @@ matrix:
   - env:
     - CLUSTER=gke
     - REGISTRY=gcr
-  - env:
-    - CLUSTER=eks
-    - REGISTRY=dockerhub
+  # EKS and Knative Build 0.3 are not happy together
+  # - env:
+  #   - CLUSTER=eks
+  #   - REGISTRY=dockerhub
   # disable pks-gcp because creating the cluster take as long as travis job time limit
   # - env:
   #   - CLUSTER=pks-gcp

--- a/tests/eventing.sh
+++ b/tests/eventing.sh
@@ -13,30 +13,56 @@ kail_test_pid=$!
 kail --ns knative-serving --ns knative-eventing > $test_name.controller.logs &
 kail_controller_pid=$!
 
-riff service create correlator --image projectriff/correlator:fats-20181214 --namespace $NAMESPACE
-wait_kservice_ready correlator $NAMESPACE
+kubectl apply -f https://storage.googleapis.com/knative-releases/eventing-sources/previous/v0.3.0/release.yaml
+wait_pod_selector_ready control-plane=controller-manager knative-sources
 
-riff channel create $test_name --cluster-provisioner in-memory-channel --namespace $NAMESPACE
-riff subscription create $test_name --channel $test_name --subscriber correlator --namespace $NAMESPACE
+kubectl apply -n $NAMESPACE -f https://storage.googleapis.com/knative-releases/eventing-sources/previous/v0.3.0/message-dumper.yaml
+wait_kservice_ready message-dumper $NAMESPACE
+
+kail --ns $NAMESPACE --label serving.knative.dev/service=message-dumper -c user-container > $test_name.output.logs &
+kail_output_pid=$!
+
+riff channel create $test_name --namespace $NAMESPACE
+riff subscription create $test_name --channel $test_name --subscriber message-dumper --namespace $NAMESPACE
 
 wait_channel_ready $test_name $NAMESPACE
 wait_subscription_ready $test_name $NAMESPACE
-sleep 5
 
-input_data=riff
-riff service invoke correlator /$NAMESPACE/$test_name --namespace $NAMESPACE --text -- \
-  -H "knative-blocking-request: true" \
-  -w'\n' \
-  -d $input_data | tee $test_name.out
-expected_data=riff
-actual_data=`cat $test_name.out | tail -1`
+cat <<EOF | kubectl apply -f -
+apiVersion: sources.eventing.knative.dev/v1alpha1
+kind: CronJobSource
+metadata:
+  name: test-cronjob-source
+  namespace: $NAMESPACE
+spec:
+  schedule: '* * * * *'
+  data: '{"message": "Hello world!"}'
+  sink:
+    apiVersion: eventing.knative.dev/v1alpha1
+    kind: Channel
+    name: $test_name
+EOF
+wait_knative_ready cronjobsource.sources.eventing.knative.dev test-cronjob-source $NAMESPACE
 
-kill $kail_test_pid $kail_controller_pid
+# cron source triggers once a minute
+sleep 75
+
+expected_data="0"
+actual_data=$(cat $test_name.output.logs | grep 'Hello world!' | wc -l)
+
+kill $kail_output_pid $kail_test_pid $kail_controller_pid
 riff subscription delete $test_name --namespace $NAMESPACE
 riff channel delete $test_name --namespace $NAMESPACE
-riff service delete correlator --namespace $NAMESPACE
+riff service delete message-dumper --namespace $NAMESPACE
+kubectl delete cronjobsource.sources.eventing.knative.dev test-cronjob-source -n $NAMESPACE
 
-if [[ "$actual_data" != "$expected_data" ]]; then
+kubectl delete ns knative-sources
+
+if [[ "$actual_data" == "$expected_data" ]]; then
+  # negative test since we'll get no matching output by default
+  fats_echo "Dumper Logs:"
+  cat $test_name.output.logs
+  echo ""
   fats_echo "Test Logs:"
   cat $test_name.logs
   echo ""


### PR DESCRIPTION
riff@master now uses Knative 0.3 which no longer supports the correlator.