### PR TITLE
Tell gcloud it's ok to remove a tag when removing an image

### DIFF
--- a/registries/gcr/configure.sh
+++ b/registries/gcr/configure.sh
@@ -15,7 +15,7 @@ fats_image_repo() {
 fats_delete_image() {
   local image=$1
 
-  gcloud container images delete $image
+  gcloud container images delete $image --force-delete-tags
 }
 
 fats_create_push_credentials() {


### PR DESCRIPTION
This fixes a breaking change in the gcloud cli that crept up yesterday