### PR TITLE
Fail the build if a tool fails to install

### DIFF
--- a/.util.sh
+++ b/.util.sh
@@ -6,8 +6,6 @@ fi
 FATS_LOADED=true
 
 source `dirname "${BASH_SOURCE[0]}"`/.travis.sh
-source `dirname "${BASH_SOURCE[0]}"`/install.sh kubectl
-source `dirname "${BASH_SOURCE[0]}"`/install.sh kail
 
 ANSI_BLUE="\033[34;1m"
 

--- a/clusters/eks/configure.sh
+++ b/clusters/eks/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install eksctl cli
-source `dirname "${BASH_SOURCE[0]}"`/../../install.sh eksctl
+`dirname "${BASH_SOURCE[0]}"`/../../install.sh eksctl
 
 SYSTEM_INSTALL_FLAGS="${SYSTEM_INSTALL_FLAGS:-}"
 

--- a/clusters/gke/configure.sh
+++ b/clusters/gke/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install gcloud cli
-source `dirname "${BASH_SOURCE[0]}"`/../../install.sh gcloud
+`dirname "${BASH_SOURCE[0]}"`/../../install.sh gcloud
 
 SYSTEM_INSTALL_FLAGS="${SYSTEM_INSTALL_FLAGS:-}"
 

--- a/clusters/minikube/configure.sh
+++ b/clusters/minikube/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install minikube cli
-source `dirname "${BASH_SOURCE[0]}"`/../../install.sh minikube
+`dirname "${BASH_SOURCE[0]}"`/../../install.sh minikube
 
 SYSTEM_INSTALL_FLAGS="${SYSTEM_INSTALL_FLAGS:---node-port}"
 

--- a/clusters/pks-gcp/configure.sh
+++ b/clusters/pks-gcp/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install pks cli
-source `dirname "${BASH_SOURCE[0]}"`/../../install.sh pks
+`dirname "${BASH_SOURCE[0]}"`/../../install.sh pks
 
 SYSTEM_INSTALL_FLAGS="${SYSTEM_INSTALL_FLAGS:-}"
 

--- a/install.sh
+++ b/install.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
-source `dirname "${BASH_SOURCE[0]}"`/.util.sh
+set -o errexit
+set -o nounset
+set -o pipefail
 
 if [ ! -f `dirname "${BASH_SOURCE[0]}"`/tools/$1.installed ]; then
+  touch `dirname "${BASH_SOURCE[0]}"`/tools/$1.installed
+  source `dirname "${BASH_SOURCE[0]}"`/.util.sh
+
   travis_fold start install-$1
   echo "Installing $1"
-  `dirname "${BASH_SOURCE[0]}"`/tools/$1.sh
-  touch `dirname "${BASH_SOURCE[0]}"`/tools/$1.installed
+  source `dirname "${BASH_SOURCE[0]}"`/tools/$1.sh
   travis_fold end install-$1
 fi

--- a/registries/ecr/configure.sh
+++ b/registries/ecr/configure.sh
@@ -3,7 +3,7 @@
 echo -e "${ANSI_RED}NOTE: ECR will not fully work until https://github.com/knative/serving/issues/1996 is resolved${ANSI_RESET}"
 
 # Install aws for ECR access
-source `dirname "${BASH_SOURCE[0]}"`/../../install.sh aws
+`dirname "${BASH_SOURCE[0]}"`/../../install.sh aws
 
 # Login for local pushes
 $(aws ecr get-login --no-include-email --region us-west-2)

--- a/registries/gcr/configure.sh
+++ b/registries/gcr/configure.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install gcloud for GCR access
-source `dirname "${BASH_SOURCE[0]}"`/../../install.sh gcloud
+`dirname "${BASH_SOURCE[0]}"`/../../install.sh gcloud
 
 IMAGE_REPOSITORY_PREFIX="gcr.io/`gcloud config get-value project`"
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --secret push-credentials"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -4,10 +4,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+`dirname "${BASH_SOURCE[0]}"`/../install.sh kubectl
+`dirname "${BASH_SOURCE[0]}"`/../install.sh kail
+
 source `dirname "${BASH_SOURCE[0]}"`/../start.sh
 
 # install riff
-source `dirname "${BASH_SOURCE[0]}"`/../install.sh riff
+`dirname "${BASH_SOURCE[0]}"`/../install.sh riff
 
 travis_fold start system-install
 echo "Installing riff system"

--- a/tools/eksctl.sh
+++ b/tools/eksctl.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Install aws cli
-source `dirname "${BASH_SOURCE[0]}"`/../install.sh aws
-source `dirname "${BASH_SOURCE[0]}"`/../install.sh aws-iam-authenticator
+`dirname "${BASH_SOURCE[0]}"`/../install.sh aws
+`dirname "${BASH_SOURCE[0]}"`/../install.sh aws-iam-authenticator
 
 eksctl_version="0.1.16"
 eksctl_dir=`mktemp -d eksctl.XXXX`

--- a/tools/pks.sh
+++ b/tools/pks.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install pivnet cli
-source `dirname "${BASH_SOURCE[0]}"`/../install.sh pivnet
+`dirname "${BASH_SOURCE[0]}"`/../install.sh pivnet
 
 # Install pks cli
 pivnet download-product-files -p pivotal-container-service -r 1.2.3 -i 268848 --accept-eula


### PR DESCRIPTION
We still want to avoid variable set within a tool install from leaking
out, so we can create a new shell when calling install.sh, enable strict
mode and then source the particular install script.