### PR TITLE
Fix minikube on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ variables:
   NAMESPACE: '$(CLUSTER_NAME)'
 
 steps:
-- script: sudo apt-get update && sudo apt-get remove docker.io && sudo apt-get autoremove && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
+- script: sudo apt list --installed && sudo apt-get update && sudo apt-get remove docker.io moby-engine moby-cli && sudo apt-get autoremove && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
   condition: and(succeeded(), eq(variables['CLUSTER'], 'minikube'))
   displayName: 'Downgrade Docker'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ variables:
   NAMESPACE: '$(CLUSTER_NAME)'
 
 steps:
-- script: sudo apt-get update && sudo apt-get remove moby && sudo apt-get autoremove && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
+- script: sudo apt-get update && sudo apt-get remove docker.io && sudo apt-get autoremove && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
   condition: and(succeeded(), eq(variables['CLUSTER'], 'minikube'))
   displayName: 'Downgrade Docker'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ variables:
   NAMESPACE: '$(CLUSTER_NAME)'
 
 steps:
-- script: sudo apt-get update && sudo apt-get install -f docker.io=18.06.1-0ubuntu1.2~16.04.1
+- script: sudo apt-get update && sudo apt-get remove moby-engine && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
   condition: and(succeeded(), eq(variables['CLUSTER'], 'minikube'))
   displayName: 'Downgrade Docker'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ variables:
   NAMESPACE: '$(CLUSTER_NAME)'
 
 steps:
-- script: sudo apt-get update && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
+- script: sudo apt-get update && sudo apt-get install -f docker.io=18.06.1-0ubuntu1.2~16.04.1
   condition: and(succeeded(), eq(variables['CLUSTER'], 'minikube'))
   displayName: 'Downgrade Docker'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ variables:
   NAMESPACE: '$(CLUSTER_NAME)'
 
 steps:
-- script: sudo apt-get update && sudo apt-get remove moby-engine && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
+- script: sudo apt-get update && sudo apt-get remove moby && sudo apt-get autoremove && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
   condition: and(succeeded(), eq(variables['CLUSTER'], 'minikube'))
   displayName: 'Downgrade Docker'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ variables:
   NAMESPACE: '$(CLUSTER_NAME)'
 
 steps:
-- script: sudo apt list --installed && sudo apt-get update && sudo apt-get remove docker.io moby-engine moby-cli && sudo apt-get autoremove && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
+- script: sudo apt-get update && sudo apt-get remove moby-engine moby-cli && sudo apt-get install docker.io=18.06.1-0ubuntu1.2~16.04.1
   condition: and(succeeded(), eq(variables['CLUSTER'], 'minikube'))
   displayName: 'Downgrade Docker'
 


### PR DESCRIPTION
The name of the installed package switched from docker.io to moby-engine
and moby-cli. So we now uninstall moby-* before installing the older
version of docker.