### PR TITLE
update minikube

### DIFF
--- a/clusters/minikube/start.sh
+++ b/clusters/minikube/start.sh
@@ -18,7 +18,7 @@ sudo minikube start --memory=8192 --cpus=4 \
   --vm-driver=${vm_driver} \
   --bootstrapper=kubeadm \
   --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook" \
-  --insecure-registry registry.kube-system.svc.cluster.local
+  --insecure-registry registry.pfs.svc.cluster.local
 
 # Fix permissions issue in AzurePipelines
 sudo chmod --recursive 777 $HOME/.minikube

--- a/registries/minikube/configure.sh
+++ b/registries/minikube/configure.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-# Allow for insecure registries
-sudo su -c "echo '{ \"insecure-registries\" : [ \"registry.kube-system.svc.cluster.local\" ] }' > /etc/docker/daemon.json"
-sudo systemctl daemon-reload
-sudo systemctl restart docker
-
-IMAGE_REPOSITORY_PREFIX="registry.kube-system.svc.cluster.local/u"
+IMAGE_REPOSITORY_PREFIX="registry.pfs.svc.cluster.local/u"
 NAMESPACE_INIT_FLAGS="${NAMESPACE_INIT_FLAGS:-} --no-secret"
 
 fats_image_repo() {

--- a/registries/minikube/start.sh
+++ b/registries/minikube/start.sh
@@ -2,10 +2,38 @@
 
 # Enable local registry
 echo "Installing a local registry"
-wait_pod_selector_ready kubernetes.io/minikube-addons=addon-manager kube-system
-sudo minikube addons enable registry
-wait_pod_selector_ready kubernetes.io/minikube-addons=registry kube-system
-registry_ip=$(kubectl get svc --namespace kube-system -l "kubernetes.io/minikube-addons=registry" -o jsonpath="{.items[0].spec.clusterIP}")
-# because we are running with --vm-driver=none the local host is minikube's host
-sudo su -c "echo \"\" >> /etc/hosts"
-sudo su -c "echo \"$registry_ip       registry.kube-system.svc.cluster.local\" >> /etc/hosts"
+#!/bin/bash
+
+# Enable local registry
+echo "Installing a local registry"
+# setup registry
+docker run -d -p 5000:5000 registry:2
+sudo sed -i 's/127.0.0.1\slocalhost/127.0.0.1     localhost registry.pfs.svc.cluster.local/g' /etc/hosts
+# create registry service
+dev_ip=172.16.1.1
+sudo ifconfig lo:0 $DEV_IP
+kubectl create namespace pfs
+cat <<EOF | kubectl create -f -
+---
+kind: Service
+apiVersion: v1
+metadata:
+    name: registry
+    namespace: pfs
+spec:
+    ports:
+    - protocol: TCP
+    port: 5000
+    targetPort: 5000
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+    name: registry
+    namespace: pfs
+subsets:
+    - addresses:
+        - ip: $dev_ip
+    ports:
+        - port: 5000
+EOF

--- a/tools/minikube.sh
+++ b/tools/minikube.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-minikube_version="v0.30.0"
+minikube_version="v1.0.0"
 
 if [ "$machine" == "MinGw" ]; then
   curl -Lo minikube.exe https://storage.googleapis.com/minikube/releases/$minikube_version/minikube-windows-amd64.exe


### PR DESCRIPTION
- speed up tests by using a local container registry outside minikube. This speeds up testing for example cnab-k8s-installer-base tests will take only 3 minutes as opposed to 13 minutes with registry in minikube.
- upgrade minikube to v1.0