### PR TITLE
Increase wait timeout for function builds

### DIFF
--- a/functions/helpers.sh
+++ b/functions/helpers.sh
@@ -16,7 +16,7 @@ create_function() {
 
     # create function
     fats_echo "Creating $function_name:"
-    riff function create $function_name $args --image $image --namespace $NAMESPACE --tail &
+    riff function create $function_name $args --image $image --namespace $NAMESPACE --tail --wait-timeout 20m
     riff handler create $function_name --function-ref $function_name --namespace $NAMESPACE --tail
 
     # TODO reduce/eliminate this sleep


### PR DESCRIPTION
The daemon-registry with minikube is so slow we need to increase the
wait timeout beyond the default 10m. Also blocking creation of the
handler so we don't have it's timeout consumed by the function.