### PR TITLE
Allow tools to be installed with a specific version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,5 +9,5 @@ if [ ! -f `dirname "${BASH_SOURCE[0]}"`/tools/$1.installed ]; then
   source `dirname "${BASH_SOURCE[0]}"`/.util.sh
 
   echo "Installing $1"
-  source `dirname "${BASH_SOURCE[0]}"`/tools/$1.sh ${@:2}
+  source `dirname "${BASH_SOURCE[0]}"`/tools/$1.sh "${2:-}" "${3:-}"
 fi

--- a/install.sh
+++ b/install.sh
@@ -9,5 +9,5 @@ if [ ! -f `dirname "${BASH_SOURCE[0]}"`/tools/$1.installed ]; then
   source `dirname "${BASH_SOURCE[0]}"`/.util.sh
 
   echo "Installing $1"
-  source `dirname "${BASH_SOURCE[0]}"`/tools/$1.sh
+  source `dirname "${BASH_SOURCE[0]}"`/tools/$1.sh ${@:2}
 fi

--- a/tools/aws-iam-authenticator.sh
+++ b/tools/aws-iam-authenticator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-version=0.4.0-alpha.1
+version=${1:-0.4.0-alpha.1}
 
 curl -s -L "https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/${version}/aws-iam-authenticator_${version}_linux_amd64" -o aws-iam-authenticator
 chmod +x aws-iam-authenticator

--- a/tools/duffle.sh
+++ b/tools/duffle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-duffle_version="0.1.0-ralpha.5%2Benglishrose"
+duffle_version="${1:-0.1.0-ralpha.5%2Benglishrose}"
 
 if [ "$machine" == "MinGw" ]; then
   curl -L https://github.com/deislabs/duffle/releases/download/${duffle_version}/duffle-windows-amd64.exe > duffle.exe

--- a/tools/eksctl.sh
+++ b/tools/eksctl.sh
@@ -4,7 +4,7 @@
 `dirname "${BASH_SOURCE[0]}"`/../install.sh aws
 `dirname "${BASH_SOURCE[0]}"`/../install.sh aws-iam-authenticator
 
-eksctl_version="0.1.16"
+eksctl_version="${1:-0.1.16}"
 eksctl_dir=`mktemp -d eksctl.XXXX`
 
 curl -s -L "https://github.com/weaveworks/eksctl/releases/download/${eksctl_version}/eksctl_Linux_amd64.tar.gz" \

--- a/tools/kubectl.sh
+++ b/tools/kubectl.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-kubectl_version="v1.12.3"
+kubectl_version="${1:-v1.12.3}"
 
 if [ "$machine" == "MinGw" ]; then
   curl -Lo kubectl.exe https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/windows/amd64/kubectl.exe

--- a/tools/minikube.sh
+++ b/tools/minikube.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-minikube_version="v1.1.0"
+minikube_version="${1:-v1.1.0}"
 
 if [ "$machine" == "MinGw" ]; then
   curl -Lo minikube.exe https://storage.googleapis.com/minikube/releases/$minikube_version/minikube-windows-amd64.exe

--- a/tools/minikube.sh
+++ b/tools/minikube.sh
@@ -2,10 +2,13 @@
 
 minikube_version="${1:-v1.1.0}"
 
+echo "minikube version: ${minikube_version}"
+
 if [ "$machine" == "MinGw" ]; then
   curl -Lo minikube.exe https://storage.googleapis.com/minikube/releases/$minikube_version/minikube-windows-amd64.exe
   mv minikube.exe /usr/bin
 else
+  echo "minikube url: https://storage.googleapis.com/minikube/releases/$minikube_version/minikube-linux-amd64"
   curl -Lo minikube https://storage.googleapis.com/minikube/releases/$minikube_version/minikube-linux-amd64
   chmod +x minikube
   sudo mv minikube /usr/local/bin/

--- a/tools/minikube.sh
+++ b/tools/minikube.sh
@@ -2,13 +2,10 @@
 
 minikube_version="${1:-v1.1.0}"
 
-echo "minikube version: ${minikube_version}"
-
 if [ "$machine" == "MinGw" ]; then
   curl -Lo minikube.exe https://storage.googleapis.com/minikube/releases/$minikube_version/minikube-windows-amd64.exe
   mv minikube.exe /usr/bin
 else
-  echo "minikube url: https://storage.googleapis.com/minikube/releases/$minikube_version/minikube-linux-amd64"
   curl -Lo minikube https://storage.googleapis.com/minikube/releases/$minikube_version/minikube-linux-amd64
   chmod +x minikube
   sudo mv minikube /usr/local/bin/

--- a/tools/pivnet.sh
+++ b/tools/pivnet.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+pivnet_version="${1:-0.0.55}"
+
 # Install pivnet cli
-curl -Lo pivnet https://github.com/pivotal-cf/pivnet-cli/releases/download/v0.0.55/pivnet-linux-amd64-0.0.55 && \
+curl -Lo pivnet https://github.com/pivotal-cf/pivnet-cli/releases/download/v${pivnet_version}/pivnet-linux-amd64-${pivnet_version} && \
   chmod +x pivnet && sudo mv pivnet /usr/local/bin/
 
 pivnet login --api-token=${PIVNET_REFRESH_TOKEN}

--- a/tools/riff.sh
+++ b/tools/riff.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-riff_version="latest"
+riff_version="${1:-latest}"
 
 if [ "$machine" == "MinGw" ]; then
   curl -L https://storage.googleapis.com/projectriff/riff-cli/releases/${riff_version}/riff-windows-amd64.zip > riff.zip


### PR DESCRIPTION
The version number may be passed as additional args to the install.sh
script. It's up to each tool to decide what to do with those args.