### PR TITLE
use duffle with a fix for schemaVersion field

### DIFF
--- a/tools/duffle.sh
+++ b/tools/duffle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-duffle_version="${1:-0.2.0-beta.1-auth}"
+duffle_version="${1:-0.2.0-beta.1-schema}"
 # base_url="${2:-https://github.com/deislabs/duffle/releases/download}"
 base_url="${2:-https://storage.googleapis.com/projectriff/internal/duffle}"
 


### PR DESCRIPTION
The default duffle version is now capable of generating the schemaVersion field that is required for installation.