### PR TITLE
Remove duffle specific bits from the FATS cluster config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FATS will:
 - configure and start an image registry defined by `$REGISTRY`
 - create, invoke (asserting correct output) and cleanup functions
 - cleanup the cluster and registry after tests are complete
-- provide common duffle install flags for the riff bundle via `$DUFFLE_RIFF_INSTALL_FLAGS`
+- provide Kubernetes Service type via `$K8S_SERVICE_TYPE`
 
 You need to:
 

--- a/clusters/eks/configure.sh
+++ b/clusters/eks/configure.sh
@@ -3,7 +3,7 @@
 # Install eksctl cli
 `dirname "${BASH_SOURCE[0]}"`/../../install.sh eksctl
 
-export DUFFLE_RIFF_INSTALL_FLAGS="${DUFFLE_RIFF_INSTALL_FLAGS:-} -s node_port=false"
+export K8S_SERVICE_TYPE=LoadBalancer
 
 wait_for_ingress_ready() {
   local name=$1

--- a/clusters/gke/configure.sh
+++ b/clusters/gke/configure.sh
@@ -3,7 +3,7 @@
 # Install gcloud cli
 `dirname "${BASH_SOURCE[0]}"`/../../install.sh gcloud
 
-export DUFFLE_RIFF_INSTALL_FLAGS="${DUFFLE_RIFF_INSTALL_FLAGS:-} -s node_port=false"
+export K8S_SERVICE_TYPE=LoadBalancer
 
 wait_for_ingress_ready() {
   local name=$1

--- a/clusters/minikube/configure.sh
+++ b/clusters/minikube/configure.sh
@@ -8,7 +8,7 @@ export MINIKUBE_WANTUPDATENOTIFICATION=false
 export MINIKUBE_WANTREPORTERRORPROMPT=false
 export MINIKUBE_HOME=$HOME
 
-export DUFFLE_RIFF_INSTALL_FLAGS="${DUFFLE_RIFF_INSTALL_FLAGS:-} -s node_port=true"
+export K8S_SERVICE_TYPE=NodePort
 
 wait_for_ingress_ready() {
   local name=$1

--- a/clusters/pks-gcp/configure.sh
+++ b/clusters/pks-gcp/configure.sh
@@ -9,7 +9,7 @@ fi
 # Install pks cli
 `dirname "${BASH_SOURCE[0]}"`/../../install.sh pks
 
-export DUFFLE_RIFF_INSTALL_FLAGS="${DUFFLE_RIFF_INSTALL_FLAGS:-} -s node_port=false"
+export K8S_SERVICE_TYPE=LoadBalancer
 
 wait_for_ingress_ready() {
   local name=$1

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -21,6 +21,8 @@ kubectl create clusterrolebinding "${duffle_k8s_service_account}-cluster-admin" 
 duffle_opts=${duffle_opts:-}
 if [[ $K8S_SERVICE_TYPE == "NodePort" ]]; then
   duffle_opts="${duffle_opts} -s node_port=true"
+else
+  duffle_opts="${duffle_opts} -s node_port=false"
 fi
 
 curl -O https://storage.googleapis.com/projectriff/riff-cnab/snapshots/riff-bundle-latest.json

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,8 +18,13 @@ duffle_k8s_namespace=${duffle_k8s_namespace:-kube-system}
 kubectl create serviceaccount "${duffle_k8s_service_account}" -n "${duffle_k8s_namespace}"
 kubectl create clusterrolebinding "${duffle_k8s_service_account}-cluster-admin" --clusterrole cluster-admin --serviceaccount "${duffle_k8s_namespace}:${duffle_k8s_service_account}"
 
+duffle_opts=${duffle_opts:-}
+if [[ $K8S_SERVICE_TYPE == "NodePort" ]]; then
+  duffle_opts="${duffle_opts} -s node_port=true"
+fi
+
 curl -O https://storage.googleapis.com/projectriff/riff-cnab/snapshots/riff-bundle-latest.json
-SERVICE_ACCOUNT=${duffle_k8s_service_account} KUBE_NAMESPACE=${duffle_k8s_namespace} duffle install riff riff-bundle-latest.json --bundle-is-file ${DUFFLE_RIFF_INSTALL_FLAGS} -d k8s
+SERVICE_ACCOUNT=${duffle_k8s_service_account} KUBE_NAMESPACE=${duffle_k8s_namespace} duffle install riff riff-bundle-latest.json --bundle-is-file ${duffle_opts} -d k8s
 
 # health checks
 echo "Checking for ready ingress"

--- a/tools/helm.sh
+++ b/tools/helm.sh
@@ -11,7 +11,7 @@ if [ "$machine" == "MinGw" ]; then
 else
   helm_dir=`mktemp -d helm.XXXX`
 
-  curl -L ${base_url}/helm-v${helm_version}-linux-amd64.tar.gz | tar xz -C $helm_dir
+  curl -L ${base_url}/helm-v${helm_version}-linux-amd64.tar.gz | tar xz -C $helm_dir --strip-components 1
   chmod +x $helm_dir/helm
   sudo mv $helm_dir/helm /usr/local/bin/
 


### PR DESCRIPTION
The cluster configuration script will now export K8S_SERVICE_TYPE with
the type of service it requires. Each installer must adapt itself to
use this value.

FATS should not bias itself towards a specific install technology or
worse, a particular installer.