### PR TITLE
Expose runtime in function helpers

### DIFF
--- a/functions/helpers.sh
+++ b/functions/helpers.sh
@@ -5,6 +5,7 @@ create_function() {
   local function_name=$2
   local image=$3
   local args=$4
+  local runtime=${5:-core}
 
   echo "Create function $function_name"
 
@@ -16,7 +17,7 @@ create_function() {
     # create function
     fats_echo "Creating $function_name:"
     riff function create $function_name $args --image $image --namespace $NAMESPACE --tail &
-    riff knative deployer create $function_name --function-ref $function_name --namespace $NAMESPACE --tail
+    riff $runtime deployer create $function_name --function-ref $function_name --namespace $NAMESPACE --tail
 
     # TODO reduce/eliminate this sleep
     sleep 5
@@ -27,13 +28,37 @@ invoke_function() {
   local function_name=$1
   local input_data=$2
   local expected_data=$3
+  local runtime=${4:-core}
 
   echo "Invoke function $function_name"
 
-  riff knative deployer invoke $function_name --namespace $NAMESPACE -- \
-    -H "Content-Type: text/plain" \
-    -d $input_data \
-    -v | tee $function_name.out
+  if [ $runtime = "core" ]; then
+    svc=$(kubectl get deployers.$runtime.projectriff.io --namespace $NAMESPACE ${function_name} -o jsonpath={.status.serviceName})
+    kubectl port-forward --namespace $NAMESPACE service/${svc} 8080:80 &
+    pf_pid=$!
+
+    # wait for the port-forward to be ready
+    if [ -x "$(command -v nc)" ]; then
+      while ! nc -z localhost 8080; do
+        sleep 1
+      done
+      sleep 2
+    else
+      sleep 5
+    fi
+
+    curl localhost:8080 \
+      -H "Content-Type: text/plain" \
+      -d $input_data \
+      -v | tee $function_name.out
+
+    kill $pf_pid
+  elif [ $runtime = "knative" ]; then
+    riff $runtime deployer invoke $function_name --namespace $NAMESPACE -- \
+      -H "Content-Type: text/plain" \
+      -d $input_data \
+      -v | tee $function_name.out
+  fi
 
   # add a new line after invoke, but without impacting the curl output
   echo ""
@@ -42,10 +67,11 @@ invoke_function() {
 destroy_function() {
   local function_name=$1
   local image=$2
+  local runtime=${3:-core}
 
   echo "Destroy function $function_name"
 
-  riff knative deployer delete $function_name --namespace $NAMESPACE
+  riff $runtime deployer delete $function_name --namespace $NAMESPACE
   riff function delete $function_name --namespace $NAMESPACE
   fats_delete_image $image
 }
@@ -57,6 +83,7 @@ run_function() {
   local create_args=$4
   local input_data=$5
   local expected_data=$6
+  local runtime=${7:-core}
 
   echo "Run function $function_name"
 
@@ -64,10 +91,11 @@ run_function() {
   echo -e "${ANSI_BLUE}> name:${ANSI_RESET} ${function_name}"
   echo -e "${ANSI_BLUE}> image:${ANSI_RESET} ${image}"
   echo -e "${ANSI_BLUE}> args:${ANSI_RESET} ${create_args}"
+  echo -e "${ANSI_BLUE}> runtime:${ANSI_RESET} ${runtime}"
 
-  create_function $path $function_name $image "$create_args"
-  invoke_function $function_name $input_data $expected_data
-  destroy_function $function_name $image
+  create_function $path $function_name $image "$create_args" $runtime
+  invoke_function $function_name $input_data $expected_data $runtime
+  destroy_function $function_name $image $runtime
 
   local actual_data=`cat $function_name.out | tail -1`
   if [ "$actual_data" != "$expected_data" ]; then

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -47,8 +47,9 @@ for test in java java-boot node npm command; do
   create_args="--git-repo $(git remote get-url origin) --git-revision $(git rev-parse HEAD) --sub-path functions/uppercase/${test}"
   input_data=fats
   expected_data=FATS
+  runtime=core
 
-  run_function $path $function_name $image "$create_args" $input_data $expected_data
+  run_function $path $function_name $image "$create_args" $input_data $expected_data $runtime
 done
 
 # local builds
@@ -61,7 +62,8 @@ if [ "$machine" != "MinGw" ]; then
     create_args="--local-path ."
     input_data=fats
     expected_data=FATS
+    runtime=knative
 
-    run_function $path $function_name $image "$create_args" $input_data $expected_data
+    run_function $path $function_name $image "$create_args" $input_data $expected_data $runtime
   done
 fi


### PR DESCRIPTION
Both the knative and core runtimes are supported. To invoke the core
runtime, a port forwarding tunnel is created for the request and then
destroyed.