### PR TITLE
Delete images with tag and digest for GCR

### DIFF
--- a/registries/gcr/configure.sh
+++ b/registries/gcr/configure.sh
@@ -21,6 +21,9 @@ fats_image_repo() {
 fats_delete_image() {
   local image=$1
 
+  # drop the tag if there is also a digest, preserving the digest
+  image=$(echo $image | sed -e 's|:[^@:]*@|@|g')
+
   gcloud container images delete $image --force-delete-tags
 }
 


### PR DESCRIPTION
`gcloud container images delete` only supports deleting a image with
either a tag or digest, but not both. Strip the tag when a digest is
present.