### PR TITLE
Delete the working namespace after system uninstall

### DIFF
--- a/ci/cleanup.sh
+++ b/ci/cleanup.sh
@@ -6,8 +6,6 @@ source `dirname "${BASH_SOURCE[0]}"`/../.util.sh
 
 # attempt to cleanup riff and the cluster
 echo "Uninstall riff system"
-kubectl delete namespace $NAMESPACE
-
 helm delete --purge riff
 kubectl delete customresourcedefinitions.apiextensions.k8s.io -l app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/instance=riff
 
@@ -18,5 +16,7 @@ kubectl delete namespace istio-system
 helm reset
 kubectl delete serviceaccount tiller -n kube-system
 kubectl delete clusterrolebinding tiller
+
+kubectl delete namespace $NAMESPACE
 
 source `dirname "${BASH_SOURCE[0]}"`/../cleanup.sh


### PR DESCRIPTION
In theory the namespace should be deletable at any time. In practice,
it's order dependent otherwise the namespace deletion hangs.