### PR TITLE
Fail remote PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,20 @@
-pr: none
-
 jobs:
+
+- job: gate
+  steps:
+  - bash: |
+      if [ $IS_FORK = 'TRUE' ] ; then
+        exit 1
+      fi
+    env:
+      IS_FORK: '$(System.PullRequest.IsFork)'
+    displayName: 'No remote PRs'
+
 - job: fats
+  dependsOn: gate
+
+  # don't run for pull requests
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
   strategy:
     matrix:


### PR DESCRIPTION
Disabling remote PRs is insufficient as the tests don't run and GitHub
reports the PR checks as passing, because none failed. We need to
actively fail PR from remote repos.

PRs from the same repo are allowed to pass, but are shortcutted to avoid
duplicate builds from the pushed commit.