### PR TITLE
Use k8s 1.14 on GKE, the default is still 1.13

### DIFF
--- a/clusters/gke/start.sh
+++ b/clusters/gke/start.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 gcloud container clusters create $CLUSTER_NAME \
-  --cluster-version=latest \
+  --cluster-version=1.14 \
   --machine-type=n1-standard-2 \
   --enable-autoscaling --min-nodes=1 --max-nodes=3 \
   --enable-autorepair \
-  --scopes=service-control,service-management,compute-rw,storage-ro,cloud-platform,logging-write,monitoring-write,pubsub,datastore \
+  --scopes=cloud-platform \
   --num-nodes=3
 
 kubectl create clusterrolebinding cluster-admin-binding \


### PR DESCRIPTION
We should set the cluster-version back to latest once 1.14 becomes the
default