### PR TITLE
Ignore checksums when installing gcloud

### DIFF
--- a/tools/gcloud.sh
+++ b/tools/gcloud.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if hash choco 2>/dev/null; then
-  choco install gcloudsdk
+  choco install gcloudsdk -yf
 
   # expose gcloud to the path
   cat <<EOF > /usr/bin/gcloud

--- a/tools/gcloud.sh
+++ b/tools/gcloud.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if hash choco 2>/dev/null; then
-  choco install gcloudsdk -yf
+  choco install gcloudsdk --ignore-checksums
 
   # expose gcloud to the path
   cat <<EOF > /usr/bin/gcloud


### PR DESCRIPTION
They are currently mismatched and it's breaking all of our builds.