### PR TITLE
Replace Minikube with Kind

### DIFF
--- a/.helpers.sh
+++ b/.helpers.sh
@@ -56,7 +56,13 @@ invoke_type() {
     ip=$(kubectl get service -n istio-system istio-ingressgateway -o jsonpath='{$.status.loadBalancer.ingress[0].ip}')
     port="80"
     if [ -z "$ip" ]; then
-      ip="localhost"
+      ip=$(kubectl get node -o jsonpath='{$.items[0].status.addresses[?(@.type=="ExternalIP")].address}')
+      if [ -z "$ip" ] ; then
+        ip=$(kubectl get node -o jsonpath='{$.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+      fi
+      if [ -z "$ip" ] ; then
+        ip=localhost
+      fi
       port=$(kubectl get service -n istio-system istio-ingressgateway -o jsonpath='{$.spec.ports[?(@.name=="http2")].nodePort}')
     fi
     hostname=$(kubectl get deployers.knative.projectriff.io --namespace $NAMESPACE ${name} -o jsonpath='{$.status.url}' | sed -e 's|http://||g')

--- a/README.md
+++ b/README.md
@@ -59,14 +59,15 @@ There are four extension points for FATS:
 
 Support is provided for:
 
+- kind
 - gke
-- minikube
 - pks-gcp
 
 To add a new cluster, create a directory under `./clusters/` and add three files:
 
 - `configure.sh` - configuration shared by the start and cleanup scripts
   - define function `wait_for_ingress_ready` that blocks until the cluster ingress is fully available
+  - define function `registry_started` that is called after the registry is started
   - do any other one time configuration for the cluster
 - `start.sh` - start the kubernetes cluster and set it as the default kubectl context
 - `cleanup.sh` - shutdown the running cluster and clean up any shared or external resources
@@ -75,9 +76,9 @@ To add a new cluster, create a directory under `./clusters/` and add three files
 
 Support is provided for:
 
+- docker-daemon (unauthenticated)
 - dockerhub
 - gcr
-- minikube (local registry via minikube addon)
 
 To add a new registry, create a directory under `./registries/` and add three files:
 
@@ -106,17 +107,34 @@ To add a new function, create a directory anywhere, adding the following files:
   - `create` - CLI arguments to pass to `riff function create`, like `--artifact` or `--handler`
 - any other files for your function if using `--local-path .`
 
+### Applications
+
+Support is provided for:
+
+- uppercase
+  - java-boot
+  - node
+
+To add a new application, create a directory anywhere, adding the following files:
+
+- `.fats`
+  - `create` - CLI arguments to pass to `riff application create`, like `--artifact` or `--handler`
+- any other files for your function if using `--local-path .`
+
 ### Tools
 
 Support is provided for:
 
 - aws
+- duffle
 - glcoud
+- helm
+- kapp
+- kind
 - kubectl
-- minikube
 - pivnet
 - pks
 - riff
-- duffle
+- ytt
 
 To add a new tool, create a file under `./tools/` as `<toolname>.sh`. Add any logic needed to install and configure the tool.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,15 +19,15 @@ jobs:
 
   strategy:
     matrix:
-      minikube:
+      kind:
         imageName: ubuntu-16.04
-        qualifier: daemon
-        cluster: minikube
+        qualifier: kind
+        cluster: kind
         registry: docker-daemon
       dockerhub:
         imageName: ubuntu-16.04
-        qualifier: minikube
-        cluster: minikube
+        qualifier: dockerhub
+        cluster: kind
         registry: dockerhub
       gke:
         imageName: ubuntu-16.04

--- a/clusters/eks/configure.sh
+++ b/clusters/eks/configure.sh
@@ -11,3 +11,9 @@ wait_for_ingress_ready() {
 
   wait_for_service_hostname $name $namespace .elb.amazonaws.com
 }
+
+registry_started() {
+  local registry=$1
+
+  # nothing to do
+}

--- a/clusters/gke/configure.sh
+++ b/clusters/gke/configure.sh
@@ -11,3 +11,9 @@ wait_for_ingress_ready() {
 
   wait_for_service_ip $name $namespace
 }
+
+registry_started() {
+  local registry=$1
+
+  # nothing to do
+}

--- a/clusters/kind/cleanup.sh
+++ b/clusters/kind/cleanup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kind delete cluster

--- a/clusters/kind/configure.sh
+++ b/clusters/kind/configure.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Install kind cli
+`dirname "${BASH_SOURCE[0]}"`/../../install.sh kind
+
+export K8S_SERVICE_TYPE=NodePort
+
+wait_for_ingress_ready() {
+  local name=$1
+  local namespace=$2
+
+  # nothing to do
+}
+
+registry_started() {
+  local registry=$1
+
+  if [ $registry = "docker-daemon" ] ; then
+    local registry_ip=$(docker inspect --format "{{.NetworkSettings.IPAddress }}" registry)
+
+    # patch /etc/containerd/config.toml
+    docker cp kind-control-plane:/etc/containerd/config.toml containerd-config.toml
+    while IFS= read -r line
+    do
+      echo "$line" >> containerd-config-patched.toml
+      if [[ $line = *'[plugins.cri.registry.mirrors]'* ]] ; then
+        spaces=$(echo "$line" | cut -d '[' -s -f 1)
+        echo -n "$spaces" >> containerd-config-patched.toml
+        echo '  [plugins.cri.registry.mirrors."registry.kube-system.svc.cluster.local:5000"]' >> containerd-config-patched.toml
+        echo -n "$spaces" >> containerd-config-patched.toml
+        echo "    endpoint = [\"http://${registry_ip}:5000\"]" >> containerd-config-patched.toml
+      fi
+    done < "containerd-config.toml"
+    docker cp containerd-config-patched.toml kind-control-plane:/etc/containerd/config.toml
+
+    # add to /etc/hosts
+    docker exec kind-control-plane bash -c "echo \"${registry_ip} registry.kube-system.svc.cluster.local\" >> /etc/hosts"
+
+    # restart containerd
+    docker exec kind-control-plane bash -c 'systemctl daemon-reload'
+    docker exec kind-control-plane bash -c 'systemctl restart containerd'
+    docker exec kind-control-plane bash -c 'systemctl restart kubelet'
+    # TODO figure out what to watch instead of sleep
+    sleep 60
+  fi
+}

--- a/clusters/kind/start.sh
+++ b/clusters/kind/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+kind create cluster --wait 5m
+
+# move kubeconfig to expected location
+cp $(kind get kubeconfig-path) ~/.kube/config

--- a/clusters/minikube/configure.sh
+++ b/clusters/minikube/configure.sh
@@ -16,3 +16,9 @@ wait_for_ingress_ready() {
 
   # nothing to do
 }
+
+registry_started() {
+  local registry=$1
+
+  # nothing to do
+}

--- a/clusters/minikube/start.sh
+++ b/clusters/minikube/start.sh
@@ -18,4 +18,4 @@ sudo -E minikube start --memory=8192 --cpus=4 \
   --vm-driver=${vm_driver} \
   --bootstrapper=kubeadm \
   --extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook" \
-  --insecure-registry registry.kube-system.svc.cluster.local
+  --insecure-registry registry.kube-system.svc.cluster.local:5000

--- a/clusters/pks-gcp/configure.sh
+++ b/clusters/pks-gcp/configure.sh
@@ -17,3 +17,9 @@ wait_for_ingress_ready() {
 
   wait_for_service_ip $name $namespace
 }
+
+registry_started() {
+  local registry=$1
+
+  # nothing to do
+}

--- a/registries/docker-daemon/cleanup.sh
+++ b/registries/docker-daemon/cleanup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
 kubectl delete service registry -n kube-system
+kubectl delete endpoint registry -n kube-system
 
-docker stop $(docker ps -q --filter ancestor=registry:2 )
+docker stop registry
+docker rm registry

--- a/registries/docker-daemon/configure.sh
+++ b/registries/docker-daemon/configure.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 daemonConfig='/etc/docker/daemon.json'
-if test -f ${daemonConfig} && grep -q registry.kube-system ${daemonConfig}; then
+if test -f ${daemonConfig} && grep -q registry.kube-system.svc.cluster.local ${daemonConfig}; then
   echo "insecure registry previously configured"
 else
   # Allow for insecure registries
   sudo mkdir -p /etc/docker
-  echo '{ "insecure-registries": [ "registry.kube-system.svc.cluster.local" ] }' | sudo tee ${daemonConfig} > /dev/null
+  echo '{ "insecure-registries": [ "registry.kube-system.svc.cluster.local:5000" ] }' | sudo tee ${daemonConfig} > /dev/null
   sudo systemctl daemon-reload
   sudo systemctl restart docker
 fi
 
-IMAGE_REPOSITORY_PREFIX="registry.kube-system.svc.cluster.local"
+IMAGE_REPOSITORY_PREFIX="registry.kube-system.svc.cluster.local:5000"
 
 fats_image_repo() {
   local function_name=$1

--- a/start.sh
+++ b/start.sh
@@ -7,3 +7,5 @@ source `dirname "${BASH_SOURCE[0]}"`/clusters/${CLUSTER}/start.sh
 
 echo "Starting registry $REGISTRY"
 source `dirname "${BASH_SOURCE[0]}"`/registries/${REGISTRY}/start.sh
+
+registry_started $REGISTRY

--- a/tools/kind.sh
+++ b/tools/kind.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+kind_version="${1:-v0.5.1}"
+base_url="${2:-https://github.com/kubernetes-sigs/kind/releases/download}"
+
+if [ "$machine" == "MinGw" ]; then
+  curl -Lo kind.exe ${base_url}/${kind_version}/kind-windows-amd64
+  mv kind.exe /usr/bin/
+else
+  curl -Lo kind ${base_url}/${kind_version}/kind-linux-amd64
+  chmod +x kind
+  sudo mv kind /usr/local/bin/
+fi


### PR DESCRIPTION
Kind (Kubernetes IN Docker) is a conformant k8s runtime optimized for testing and CI environments. To run unauthenticated FATS jobs, we previously used Minikube, which is optimized for developer desktop environments and was a bit tacky and fragile in CI. (I had major trouble getting either Minikube 1.4 or K8s 1.14 working in CI without a lot of hoops, kind just worked). 

As a major perk, running with the docker-daemon registry is much faster, and is only marginally slower than dockerhub (with Minikube runs took twice as long).

The Minikube scripts are still in this repo, but are now untested and should be removed once other project have migrated to Kind.