### PR TITLE
Reintroduce basic log folding

### DIFF
--- a/.helpers.sh
+++ b/.helpers.sh
@@ -100,7 +100,7 @@ run_type() {
   local expected_data=$7
   local runtime=${8:-core}
 
-  echo "Run $type $name"
+  echo "##[group]Run $type $name"
 
   echo -e "${ANSI_BLUE}> path:${ANSI_RESET} ${path}"
   echo -e "${ANSI_BLUE}> name:${ANSI_RESET} ${name}"
@@ -119,4 +119,6 @@ run_type() {
     echo -e "   actual: $actual_data"
     exit 1
   fi
+
+  echo "##[endgroup]"
 }

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -2,8 +2,10 @@
 
 source `dirname "${BASH_SOURCE[0]}"`/.configure.sh
 
-echo "Cleanup registry $REGISTRY"
+echo "##[group]Cleanup registry $REGISTRY"
 source `dirname "${BASH_SOURCE[0]}"`/registries/${REGISTRY}/cleanup.sh
+echo "##[endgroup]"
 
-echo "Cleanup cluster $CLUSTER"
+echo "##[group]Cleanup cluster $CLUSTER"
 source `dirname "${BASH_SOURCE[0]}"`/clusters/${CLUSTER}/cleanup.sh
+echo "##[endgroup]"

--- a/start.sh
+++ b/start.sh
@@ -2,10 +2,11 @@
 
 source `dirname "${BASH_SOURCE[0]}"`/.configure.sh
 
-echo "Starting cluster $CLUSTER"
+echo "##[group]Starting cluster $CLUSTER"
 source `dirname "${BASH_SOURCE[0]}"`/clusters/${CLUSTER}/start.sh
+echo "##[endgroup]"
 
-echo "Starting registry $REGISTRY"
+echo "##[group]Starting registry $REGISTRY"
 source `dirname "${BASH_SOURCE[0]}"`/registries/${REGISTRY}/start.sh
-
 post_registry_start $REGISTRY
+echo "##[endgroup]"


### PR DESCRIPTION
FATS previously had rich log folding when running on Travis, but AZP
didn't support the capability, so we removed the support.

Since GitHub Actions supports a single level of log folding, we can
reintroduce basic support.