### PR TITLE
Create reusable macros for common bits of config

### DIFF
--- a/ci/cleanup.sh
+++ b/ci/cleanup.sh
@@ -2,14 +2,14 @@
 
 set -o nounset
 
-source `dirname "${BASH_SOURCE[0]}"`/../.util.sh
+fats_dir=`dirname "${BASH_SOURCE[0]}"`/..
 
-# attempt to cleanup riff and the cluster
-echo "Remove riff and Knative resources"
-kubectl delete riff --all-namespaces --all
-kubectl delete knative --all-namespaces --all
+source ${fats_dir}/.util.sh
 
 echo "Uninstall riff system"
+
+source $fats_dir/macros/cleanup-user-resources.sh
+
 helm delete --purge riff
 kubectl delete customresourcedefinitions.apiextensions.k8s.io -l app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/instance=riff
 
@@ -17,10 +17,8 @@ helm delete --purge istio
 kubectl delete customresourcedefinitions.apiextensions.k8s.io -l app.kubernetes.io/managed-by=Tiller,app.kubernetes.io/instance=istio
 kubectl delete namespace istio-system
 
-helm reset
-kubectl delete serviceaccount tiller -n kube-system
-kubectl delete clusterrolebinding tiller
+source $fats_dir/macros/helm-reset.sh
 
 kubectl delete namespace $NAMESPACE
 
-source `dirname "${BASH_SOURCE[0]}"`/../cleanup.sh
+source ${fats_dir}/cleanup.sh

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -12,28 +12,16 @@ source $fats_dir/start.sh
 $fats_dir/install.sh riff
 $fats_dir/install.sh helm
 
-if [ $(kubectl get nodes -oname | wc -l) = "1" ]; then
-  echo "Elimiate pod resource requests"
-  kubectl create namespace cert-manager
-  kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
-  kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.10.1/cert-manager.yaml
-  wait_pod_selector_ready app.kubernetes.io/name=cert-manager cert-manager
-  wait_pod_selector_ready app.kubernetes.io/name=cainjector cert-manager
-  wait_pod_selector_ready app.kubernetes.io/name=webhook cert-manager
-  fats_retry kubectl apply -f https://storage.googleapis.com/projectriff/no-resource-requests-webhook/no-resource-requests-webhook.yaml
-  wait_pod_selector_ready app=webhook no-resource-requests
-fi
-
 echo "Installing riff system"
 
-kubectl create serviceaccount tiller -n kube-system
-kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount kube-system:tiller
-helm init --wait --service-account tiller
+source $fats_dir/macros/no-resource-requests.sh
+source $fats_dir/macros/helm-init.sh
 
 helm repo add projectriff https://projectriff.storage.googleapis.com/charts/releases
 helm repo update
 
-helm install projectriff/istio --name istio --namespace istio-system --devel --wait --set gateways.istio-ingressgateway.type=${K8S_SERVICE_TYPE}
+helm install projectriff/istio --name istio --namespace istio-system --devel --wait \
+  --set gateways.istio-ingressgateway.type=${K8S_SERVICE_TYPE}
 helm install projectriff/riff --name riff --devel \
   --set riff.runtimes.core.enabled=true \
   --set riff.runtimes.knative.enabled=true

--- a/macros/cert-manager-install.sh
+++ b/macros/cert-manager-install.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+kubectl create namespace cert-manager
+kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.10.1/cert-manager.yaml
+
+sleep 10
+
+wait_pod_selector_ready app.kubernetes.io/name=cert-manager cert-manager
+wait_pod_selector_ready app.kubernetes.io/name=cainjector cert-manager
+wait_pod_selector_ready app.kubernetes.io/name=webhook cert-manager

--- a/macros/cleanup-user-resources.sh
+++ b/macros/cleanup-user-resources.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Remove riff and Knative resources"
+kubectl delete riff --all-namespaces --all
+kubectl delete knative --all-namespaces --all

--- a/macros/helm-init.sh
+++ b/macros/helm-init.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+kubectl create serviceaccount tiller -n kube-system
+kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount kube-system:tiller
+helm init --wait --service-account tiller

--- a/macros/helm-reset.sh
+++ b/macros/helm-reset.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+helm reset
+kubectl delete serviceaccount tiller -n kube-system
+kubectl delete clusterrolebinding tiller

--- a/macros/no-resource-requests.sh
+++ b/macros/no-resource-requests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ $(kubectl get nodes -oname | wc -l) = "1" ]; then
+  echo "Elimiate pod resource requests"
+
+  source $(dirname "${BASH_SOURCE[0]}")/cert-manager-install.sh
+
+  fats_retry kubectl apply -f https://storage.googleapis.com/projectriff/no-resource-requests-webhook/no-resource-requests-webhook.yaml
+  wait_pod_selector_ready app=webhook no-resource-requests
+fi


### PR DESCRIPTION
Macros are intended as mildly-opinionated, reusable scripts. THe goal is
to share snippets of behavior that are common across different FATS
consumers. Individual FATS consumers may use these macros, or may
continue to do their own thing.