### PR TITLE
Use explicit cluster name for kind

### DIFF
--- a/clusters/kind/cleanup.sh
+++ b/clusters/kind/cleanup.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-kind delete cluster
+kind delete cluster --name fats

--- a/clusters/kind/start.sh
+++ b/clusters/kind/start.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-kind create cluster --wait 5m
+kind create cluster --name fats --wait 5m
+
+if grep -q docker /proc/1/cgroup; then
+    # running in a container
+    flags=--internal
+fi
 
 # move kubeconfig to expected location
-cp $(kind get kubeconfig-path) ~/.kube/config
+cp <(kind get kubeconfig --name fats $flags) ~/.kube/config

--- a/macros/no-resource-requests.sh
+++ b/macros/no-resource-requests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ $(kubectl get nodes -oname | wc -l) = "1" ]; then
-  echo "Elimiate pod resource requests"
+  echo "Eliminate pod resource requests"
   fats_retry kubectl apply -f https://storage.googleapis.com/projectriff/no-resource-requests-webhook/no-resource-requests-webhook.yaml
   wait_pod_selector_ready app=webhook no-resource-requests
 fi


### PR DESCRIPTION
That way, if the default cluster happens to already be running
it won't fail.

Also checks if fats is running in a container, and if it is adds
a flag to the kubectl config generator.