### PR TITLE
Capture Knative Activator logs

### DIFF
--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -74,3 +74,10 @@ echo "##[endgroup]"
 echo "##[group]Knative Serving logs (previous)"
 kubectl logs -p -n knative-serving -l app=controller --tail 10000
 echo "##[endgroup]"
+
+echo "##[group]Knative Serving Activator logs"
+kubectl logs -n knative-serving -l app=activator --tail 10000
+echo "##[endgroup]"
+echo "##[group]Knative Serving Activator logs (previous)"
+kubectl logs -p -n knative-serving -l app=activator --tail 10000
+echo "##[endgroup]"


### PR DESCRIPTION
The Knative Serving Activator frequently enters a crashloop when
deploying Knative. While we don't know why right now, it only occurs on
GCP hosted clusters. Multiple clusters seems to have this issue all at
the same time which is indicative of an issue with GCP itself.

Hopefully logs will provide insight.