### PR TITLE
Gives riff-dev service account read access to secrets

### DIFF
--- a/macros/create-riff-dev-pod.sh
+++ b/macros/create-riff-dev-pod.sh
@@ -4,7 +4,9 @@
 utils_version=latest
 
 kubectl create serviceaccount riff-dev --namespace $NAMESPACE
-kubectl create rolebinding riff-dev --namespace $NAMESPACE --clusterrole=view --serviceaccount=${NAMESPACE}:riff-dev
+kubectl create role view-secrets --namespace $NAMESPACE --resource secrets --verb get,watch,list
+kubectl create rolebinding riff-dev-view --namespace $NAMESPACE --clusterrole=view --serviceaccount=${NAMESPACE}:riff-dev
+kubectl create rolebinding riff-dev-view-secrets --namespace $NAMESPACE --role=view-secrets --serviceaccount=${NAMESPACE}:riff-dev
 
 cat <<EOF | kubectl apply -f -
 apiVersion: v1


### PR DESCRIPTION
This will be required when the dev tools read the stream address from the binding rather than the stream status.