### PR TITLE
Use distinct repo for each image

### DIFF
--- a/registries/docker-daemon/configure.sh
+++ b/registries/docker-daemon/configure.sh
@@ -22,7 +22,7 @@ IMAGE_REPOSITORY_PREFIX="registry.kube-system.svc.cluster.local:5000"
 fats_image_repo() {
   local function_name=$1
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}/${CLUSTER_NAME}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}/${CLUSTER_NAME}:latest"
 }
 
 fats_delete_image() {

--- a/registries/docker-daemon/configure.sh
+++ b/registries/docker-daemon/configure.sh
@@ -22,7 +22,7 @@ IMAGE_REPOSITORY_PREFIX="registry.kube-system.svc.cluster.local:5000"
 fats_image_repo() {
   local function_name=$1
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}:${CLUSTER_NAME}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}/${CLUSTER_NAME}"
 }
 
 fats_delete_image() {

--- a/registries/dockerhub/configure.sh
+++ b/registries/dockerhub/configure.sh
@@ -8,7 +8,7 @@ IMAGE_REPOSITORY_PREFIX="${DOCKER_USERNAME}"
 fats_image_repo() {
   local function_name=$1
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}:${CLUSTER_NAME}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}-${CLUSTER_NAME}"
 }
 
 fats_delete_image() {

--- a/registries/dockerhub/configure.sh
+++ b/registries/dockerhub/configure.sh
@@ -8,7 +8,7 @@ IMAGE_REPOSITORY_PREFIX="${DOCKER_USERNAME}"
 fats_image_repo() {
   local function_name=$1
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}-${CLUSTER_NAME}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}-${CLUSTER_NAME}:latest"
 }
 
 fats_delete_image() {

--- a/registries/ecr/configure.sh
+++ b/registries/ecr/configure.sh
@@ -17,7 +17,7 @@ fats_image_repo() {
   # allow to fail since the repository may already exist
   aws ecr create-repository --repository-name $function_name --region us-west-2 1>&2 || true
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}:${CLUSTER_NAME}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}/${CLUSTER_NAME}"
 }
 
 fats_delete_image() {

--- a/registries/ecr/configure.sh
+++ b/registries/ecr/configure.sh
@@ -15,9 +15,9 @@ fats_image_repo() {
 
   # ECR requires the repo be created before pushing an image.
   # allow to fail since the repository may already exist
-  aws ecr create-repository --repository-name $function_name --region us-west-2 1>&2 || true
+  aws ecr create-repository --repository-name "${function_name}/${CLUSTER_NAME}" --region us-west-2 1>&2 || true
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}/${CLUSTER_NAME}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}/${CLUSTER_NAME}:latest"
 }
 
 fats_delete_image() {

--- a/registries/gcr/configure.sh
+++ b/registries/gcr/configure.sh
@@ -15,7 +15,7 @@ IMAGE_REPOSITORY_PREFIX="gcr.io/`gcloud config get-value project`"
 fats_image_repo() {
   local function_name=$1
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}:${CLUSTER_NAME}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}/${CLUSTER_NAME}"
 }
 
 fats_delete_image() {

--- a/registries/gcr/configure.sh
+++ b/registries/gcr/configure.sh
@@ -15,7 +15,7 @@ IMAGE_REPOSITORY_PREFIX="gcr.io/`gcloud config get-value project`"
 fats_image_repo() {
   local function_name=$1
 
-  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}/${CLUSTER_NAME}"
+  echo -n "${IMAGE_REPOSITORY_PREFIX}/${function_name}/${CLUSTER_NAME}:latest"
 }
 
 fats_delete_image() {


### PR DESCRIPTION
CNB will build images with the same digest given the same buildpacks and
source. This is a good thing, but means that concurrent FATS runs may
collide if they happen to be building images in the same repo.

This change creates a unique repo for each image rather then using tags
within the same repo to distinguish images.