### PR TITLE
Cleanup tests

### DIFF
--- a/diagnostics.sh
+++ b/diagnostics.sh
@@ -34,8 +34,16 @@ echo "##[group]describe riff"
 kubectl describe riff --all-namespaces
 echo "##[endgroup]"
 
+echo "##[group]describe kpack"
+kubectl describe kpack --all-namespaces
+echo "##[endgroup]"
+
 echo "##[group]describe knative"
 kubectl describe knative --all-namespaces
+echo "##[endgroup]"
+
+echo "##[group]describe pods"
+kubectl describe pods --all-namespaces
 echo "##[endgroup]"
 
 echo "##[group]riff Build logs"


### PR DESCRIPTION
Avoid DNS caches inside the dev-utils pod when invoking different deployers with the same name. The DNS TTL is 30s by default, but we're invoking, deleting the deployer, creating the deployer and invoking within the window. When that happens the second invoke will try to connect to a service ip that is no exists.